### PR TITLE
Fix hash keys values collision bug

### DIFF
--- a/lib/SPVM/Hash.spvm
+++ b/lib/SPVM/Hash.spvm
@@ -200,7 +200,7 @@ package SPVM::Hash {
     for (my $i = 0; $i < $self->{bucket_count}; ++$i) {
       my $ref = $self->{entries}->[$i];
       while ($ref) {
-        $retval->[$count++] = copy_string($self->{entries}->[$i]->key);
+        $retval->[$count++] = copy_string($ref->key);
         $ref = $ref->next_entry;
       }
     }
@@ -214,7 +214,7 @@ package SPVM::Hash {
     for (my $i = 0; $i < $self->{bucket_count}; ++$i) {
       my $ref = $self->{entries}->[$i];
       while ($ref) {
-        $retval->[$count++] = $self->{entries}->[$i]->val;
+        $retval->[$count++] = $ref->val;
         $ref = $ref->next_entry;
       }
     }

--- a/t/default/lib/TestCase/Hash.spvm
+++ b/t/default/lib/TestCase/Hash.spvm
@@ -351,13 +351,13 @@ package TestCase::Hash {
   }
 
   sub test_keys : int () {
-    my $hashmap = SPVM::Hash->new;
+    my $hash = SPVM::Hash->new;
     my $keys = ["a", "bb", "12345"];
     my $vals = [SPVM::Int->new(1), SPVM::Int->new(2), SPVM::Int->new(3)];
     for (my $i = 0; $i < @$keys; ++$i) {
-      $hashmap->set($keys->[$i], $vals->[$i]);
+      $hash->set($keys->[$i], $vals->[$i]);
     }
-    my $got_keys = $hashmap->keys;
+    my $got_keys = $hash->keys;
     unless (@$got_keys == @$keys) {
       return 0;
     }
@@ -377,13 +377,13 @@ package TestCase::Hash {
   }
 
   sub test_values : int () {
-    my $hashmap = SPVM::Hash->new;
+    my $hash = SPVM::Hash->new;
     my $keys = ["a", "bb", "12345"];
     my $vals = [SPVM::Int->new(1), SPVM::Int->new(1), SPVM::Int->new(9)];
     for (my $i = 0; $i < @$keys; ++$i) {
-      $hashmap->set($keys->[$i], $vals->[$i]);
+      $hash->set($keys->[$i], $vals->[$i]);
     }
-    my $got_vals = $hashmap->values;
+    my $got_vals = $hash->values;
     unless (@$got_vals == @$vals) {
       return 0;
     }

--- a/t/default/lib/TestCase/Hash.spvm
+++ b/t/default/lib/TestCase/Hash.spvm
@@ -426,23 +426,63 @@ package TestCase::Hash {
     my $capacity = 16;
     my $hash = SPVM::Hash->new_with_capacity($capacity);
     $hash->{max_load_factor} = 1024 * 16 + 1; # large enough not to rehash.
+    my $keys = new string [1024];
+    my $vals = new object [1024];
     for (my $i = 0; $i < 1024; ++$i) {
       my $byte_key = (byte []) "AA"; # 32^2 = 1024. 32: [A-Za-z]
       $byte_key->[0] += $i / 32;
       $byte_key->[1] += $i % 32;
-      $hash->set((string)$byte_key, SPVM::Int->new($i));
+      $keys->[$i] = (string)$byte_key;
+      $vals->[$i] = SPVM::Int->new($i);
+      $hash->set($keys->[$i], $vals->[$i]);
     }
     # guarantee that rehash doesn't occur.
     unless ($hash->_bucket_count == $capacity) {
       return 0;
     }
+
+    # test set/get
     for (my $i = 0; $i < 1024; ++$i) {
-      my $byte_key = (byte []) "AA";
-      $byte_key->[0] += $i / 32;
-      $byte_key->[1] += $i % 32;
-      unless (((SPVM::Int)$hash->get((string)$byte_key))->val == $i) {
+      my $lhs = (SPVM::Int)$hash->get($keys->[$i]);
+      my $rhs = (SPVM::Int)$vals->[$i];
+      unless ($lhs->val == $rhs->val) {
         return 0;
-      };
+      }
+    }
+
+    # test keys
+    my $got_keys = $hash->keys;
+    my $lhs = new object [@$got_keys];
+    for (my $i = 0; $i < @$got_keys; $i++) {
+      $lhs->[$i] = $got_keys->[$i];
+    }
+    my $rhs = new object [@$keys];
+    for (my $i = 0; $i < @$keys; $i++) {
+      $rhs->[$i] = $keys->[$i];
+    }
+    my $strcmp = sub : int ($self : self, $lhs : object, $rhs : object) {
+      my $s = (string)$lhs;
+      my $t = (string)$rhs;
+      unless ($s eq $t) {
+        return 0;
+      }
+      return 1;
+    };
+    unless (_same_unordered_objects($lhs, $rhs, $strcmp)) {
+      return 0;
+    }
+
+    # test values
+    my $intcmp = sub : int ($self : self, $lhs : object, $rhs : object) {
+      my $x = (SPVM::Int)$lhs;
+      my $y = (SPVM::Int)$rhs;
+      unless ($x->val == $y->val) {
+        return 0;
+      }
+      return 1;
+    };
+    unless (_same_unordered_objects($hash->values, $vals, $intcmp)) {
+      return 0;
     }
     return 1;
   }

--- a/t/default/lib/TestCase/Hash.spvm
+++ b/t/default/lib/TestCase/Hash.spvm
@@ -1,6 +1,7 @@
 package TestCase::Hash {
   use SPVM::Int;
   use SPVM::Hash;
+  use SPVM::Comparator;
 
   sub test_murmur_hash : int () {
     my $seed = 123456789;
@@ -350,6 +351,32 @@ package TestCase::Hash {
     return 1;
   }
 
+  sub _same_unordered_objects : int ($lhs : object[], $rhs : object[], $comparator : SPVM::Comparator) {
+    unless (@$lhs == @$rhs) {
+      return 0;
+    }
+    my $rhs_used = new int [@$rhs];
+    for (my $i = 0; $i < @$lhs; ++$i) {
+      my $found = 0;
+      for (my $j = 0; $j < @$rhs; ++$j) {
+        if (!$rhs_used->[$j] && $comparator->compare($lhs->[$i], $rhs->[$j])) {
+          $found = 1;
+          $rhs_used->[$j] = 1;
+          last;
+        }
+      }
+      unless ($found) {
+        return 0;
+      }
+    }
+    for (my $i = 0; $i < @$rhs_used; $i++) {
+      unless ($rhs_used->[$i]) {
+        return 0;
+      }
+    }
+    return 1;
+  }
+
   sub test_keys : int () {
     my $hash = SPVM::Hash->new;
     my $keys = ["a", "bb", "12345"];
@@ -358,45 +385,41 @@ package TestCase::Hash {
       $hash->set($keys->[$i], $vals->[$i]);
     }
     my $got_keys = $hash->keys;
-    unless (@$got_keys == @$keys) {
-      return 0;
+    my $lhs = new object [@$got_keys];
+    for (my $i = 0; $i < @$got_keys; $i++) {
+      $lhs->[$i] = $got_keys->[$i];
     }
-    # cmp_deeply( $got_keys, bag(@$keys) );
-    for (my $i = 0; $i < @$got_keys; ++$i) {
-      my $found = 0;
-      for (my $j = 0; $j < @$keys; ++$j) {
-        if ($got_keys->[$i] eq $keys->[$j]) {
-          $found = 1;
-        }
-      }
-      unless ($found) {
+    my $rhs = new object [@$keys];
+    for (my $i = 0; $i < @$keys; $i++) {
+      $rhs->[$i] = $keys->[$i];
+    }
+    my $comparator = sub : int ($self : self, $lhs : object, $rhs : object) {
+      my $s = (string)$lhs;
+      my $t = (string)$rhs;
+      unless ($s eq $t) {
         return 0;
       }
-    }
-    return 1;
+      return 1;
+    };
+    return _same_unordered_objects($lhs, $rhs, $comparator);
   }
 
   sub test_values : int () {
     my $hash = SPVM::Hash->new;
     my $keys = ["a", "bb", "12345"];
-    my $vals = [SPVM::Int->new(1), SPVM::Int->new(1), SPVM::Int->new(9)];
+    my $vals = [(object) SPVM::Int->new(1), SPVM::Int->new(2), SPVM::Int->new(3)];
     for (my $i = 0; $i < @$keys; ++$i) {
       $hash->set($keys->[$i], $vals->[$i]);
     }
-    my $got_vals = $hash->values;
-    unless (@$got_vals == @$vals) {
-      return 0;
-    }
-    my $count_1 = 0;
-    my $count_9 = 0;
-    for (my $i = 0; $i < @$got_vals; ++$i) {
-      if (((SPVM::Int)$got_vals->[$i])->val == 1) { $count_1++; }
-      if (((SPVM::Int)$got_vals->[$i])->val == 9) { $count_9++; }
-    }
-    unless ($count_1 == 2 && $count_9 == 1) {
-      return 0;
-    }
-    return 1;
+    my $comparator = sub : int ($self : self, $lhs : object, $rhs : object) {
+      my $x = (SPVM::Int)$lhs;
+      my $y = (SPVM::Int)$rhs;
+      unless ($x->val == $y->val) {
+        return 0;
+      }
+      return 1;
+    };
+    return _same_unordered_objects($hash->values, $vals, $comparator);
   }
 
   sub test_many_hash_collisions : int () {


### PR DESCRIPTION
`SPVM::Hash` の `keys`, `values` メソッドのバク修正です。
衝突が発生した場合に `keys`, `values` の取得が正しく出来ないものを修正します。
衝突のテストは既に存在しますが、`get`, `set` しかテストされておりませんでした。
こちらに `keys`, `values` のテストも追加し、他に少しテストのリファクタをしました。