### PR TITLE
[#32 マージ待ち] Refactor/use accessor in SPVM::HashEntry

### DIFF
--- a/lib/SPVM/Hash.spvm
+++ b/lib/SPVM/Hash.spvm
@@ -200,7 +200,7 @@ package SPVM::Hash {
     for (my $i = 0; $i < $self->{bucket_count}; ++$i) {
       my $ref = $self->{entries}->[$i];
       while ($ref) {
-        $retval->[$count++] = copy_string($self->{entries}->[$i]->key);
+        $retval->[$count++] = copy_string($ref->key);
         $ref = $ref->next_entry;
       }
     }
@@ -214,7 +214,7 @@ package SPVM::Hash {
     for (my $i = 0; $i < $self->{bucket_count}; ++$i) {
       my $ref = $self->{entries}->[$i];
       while ($ref) {
-        $retval->[$count++] = $self->{entries}->[$i]->val;
+        $retval->[$count++] = $ref->val;
         $ref = $ref->next_entry;
       }
     }

--- a/lib/SPVM/Hash.spvm
+++ b/lib/SPVM/Hash.spvm
@@ -29,16 +29,16 @@ package SPVM::Hash {
       return;
     }
     while (1) {
-      if ($ref->key eq $key) {
-        $ref->set_val($val);
+      if ($ref->{key} eq $key) {
+        $ref->{val} = $val;
         return;
       }
-      unless ($ref->next_entry) {
-        $ref->set_next_entry(SPVM::HashEntry->new($key, $val, undef));
+      unless ($ref->{next_entry}) {
+        $ref->{next_entry} = SPVM::HashEntry->new($key, $val, undef);
         ++$$count_ref;
         return;
       }
-      $ref = $ref->next_entry;
+      $ref = $ref->{next_entry};
     }
   }
 
@@ -59,8 +59,8 @@ package SPVM::Hash {
     for (my $i = 0; $i < $self->{bucket_count}; ++$i) {
       my $ref = $self->{entries}->[$i];
       while ($ref) {
-        _set_to_container($new_entries, $new_bucket_count, \$new_count, $ref->key, $ref->val);
-        $ref = $ref->next_entry;
+        _set_to_container($new_entries, $new_bucket_count, \$new_count, $ref->{key}, $ref->{val});
+        $ref = $ref->{next_entry};
       }
     }
     $self->{bucket_count} = $new_bucket_count;
@@ -135,13 +135,13 @@ package SPVM::Hash {
       return undef;
     }
     while (1) {
-      if ($ref->key eq $key) {
-        return $ref->val;
+      if ($ref->{key} eq $key) {
+        return $ref->{val};
       }
-      unless ($ref->next_entry) {
+      unless ($ref->{next_entry}) {
         return undef;
       }
-      $ref = $ref->next_entry;
+      $ref = $ref->{next_entry};
     }
   }
 
@@ -152,13 +152,13 @@ package SPVM::Hash {
       return 0;
     }
     while (1) {
-      if ($ref->key eq $key) {
+      if ($ref->{key} eq $key) {
         return 1;
       }
-      unless ($ref->next_entry) {
+      unless ($ref->{next_entry}) {
         return 0;
       }
-      $ref = $ref->next_entry;
+      $ref = $ref->{next_entry};
     }
   }
 
@@ -170,22 +170,22 @@ package SPVM::Hash {
       return 0;
     }
     while (1) {
-      if ($ref->key eq $key) {
-        my $ret = $ref->val;
+      if ($ref->{key} eq $key) {
+        my $ret = $ref->{val};
         if ($prev) {
-          $prev->set_next_entry($ref->next_entry);
+          $prev->{next_entry} = $ref->{next_entry};
         }
         else {
-          $self->{entries}->[$index] = $ref->next_entry;
+          $self->{entries}->[$index] = $ref->{next_entry};
         }
         $self->{count}--;
         return $ret;
       }
-      unless ($ref->next_entry) {
+      unless ($ref->{next_entry}) {
         return undef;
       }
       $prev = $ref;
-      $ref = $ref->next_entry;
+      $ref = $ref->{next_entry};
     }
   }
 
@@ -200,8 +200,8 @@ package SPVM::Hash {
     for (my $i = 0; $i < $self->{bucket_count}; ++$i) {
       my $ref = $self->{entries}->[$i];
       while ($ref) {
-        $retval->[$count++] = copy_string($ref->key);
-        $ref = $ref->next_entry;
+        $retval->[$count++] = copy_string($ref->{key});
+        $ref = $ref->{next_entry};
       }
     }
     return $retval;
@@ -214,8 +214,8 @@ package SPVM::Hash {
     for (my $i = 0; $i < $self->{bucket_count}; ++$i) {
       my $ref = $self->{entries}->[$i];
       while ($ref) {
-        $retval->[$count++] = $ref->val;
-        $ref = $ref->next_entry;
+        $retval->[$count++] = $ref->{val};
+        $ref = $ref->{next_entry};
       }
     }
     return $retval;

--- a/lib/SPVM/HashEntry.spvm
+++ b/lib/SPVM/HashEntry.spvm
@@ -1,7 +1,7 @@
 package SPVM::HashEntry {
-  has key : string;
-  has val : object;
-  has next_entry : SPVM::HashEntry;
+  has key : public string;
+  has val : public object;
+  has next_entry : public SPVM::HashEntry;
     
   sub new : SPVM::HashEntry ($key : string, $val : object, $next_entry : SPVM::HashEntry) {
     my $self = new SPVM::HashEntry;
@@ -9,25 +9,5 @@ package SPVM::HashEntry {
     $self->{val} = $val;
     $self->{next_entry} = $next_entry;
     return $self;
-  }
-
-  sub key : string ($self : self) {
-    return $self->{key};
-  }
-
-  sub val : object ($self : self) {
-    return $self->{val};
-  }
-
-  sub next_entry : SPVM::HashEntry ($self : self) {
-    return $self->{next_entry};
-  }
-
-  sub set_val : void ($self : self, $value : object) {
-    $self->{val} = $value;
-  }
-
-  sub set_next_entry : void ($self : self, $next_entry : SPVM::HashEntry) {
-    $self->{next_entry} = $next_entry;
   }
 }

--- a/t/default/lib/TestCase/Hash.spvm
+++ b/t/default/lib/TestCase/Hash.spvm
@@ -351,13 +351,13 @@ package TestCase::Hash {
   }
 
   sub test_keys : int () {
-    my $hashmap = SPVM::Hash->new;
+    my $hash = SPVM::Hash->new;
     my $keys = ["a", "bb", "12345"];
     my $vals = [SPVM::Int->new(1), SPVM::Int->new(2), SPVM::Int->new(3)];
     for (my $i = 0; $i < @$keys; ++$i) {
-      $hashmap->set($keys->[$i], $vals->[$i]);
+      $hash->set($keys->[$i], $vals->[$i]);
     }
-    my $got_keys = $hashmap->keys;
+    my $got_keys = $hash->keys;
     unless (@$got_keys == @$keys) {
       return 0;
     }
@@ -377,13 +377,13 @@ package TestCase::Hash {
   }
 
   sub test_values : int () {
-    my $hashmap = SPVM::Hash->new;
+    my $hash = SPVM::Hash->new;
     my $keys = ["a", "bb", "12345"];
     my $vals = [SPVM::Int->new(1), SPVM::Int->new(1), SPVM::Int->new(9)];
     for (my $i = 0; $i < @$keys; ++$i) {
-      $hashmap->set($keys->[$i], $vals->[$i]);
+      $hash->set($keys->[$i], $vals->[$i]);
     }
-    my $got_vals = $hashmap->values;
+    my $got_vals = $hash->values;
     unless (@$got_vals == @$vals) {
       return 0;
     }

--- a/t/default/lib/TestCase/Hash.spvm
+++ b/t/default/lib/TestCase/Hash.spvm
@@ -426,23 +426,63 @@ package TestCase::Hash {
     my $capacity = 16;
     my $hash = SPVM::Hash->new_with_capacity($capacity);
     $hash->{max_load_factor} = 1024 * 16 + 1; # large enough not to rehash.
+    my $keys = new string [1024];
+    my $vals = new object [1024];
     for (my $i = 0; $i < 1024; ++$i) {
       my $byte_key = (byte []) "AA"; # 32^2 = 1024. 32: [A-Za-z]
       $byte_key->[0] += $i / 32;
       $byte_key->[1] += $i % 32;
-      $hash->set((string)$byte_key, SPVM::Int->new($i));
+      $keys->[$i] = (string)$byte_key;
+      $vals->[$i] = SPVM::Int->new($i);
+      $hash->set($keys->[$i], $vals->[$i]);
     }
     # guarantee that rehash doesn't occur.
     unless ($hash->_bucket_count == $capacity) {
       return 0;
     }
+
+    # test set/get
     for (my $i = 0; $i < 1024; ++$i) {
-      my $byte_key = (byte []) "AA";
-      $byte_key->[0] += $i / 32;
-      $byte_key->[1] += $i % 32;
-      unless (((SPVM::Int)$hash->get((string)$byte_key))->val == $i) {
+      my $lhs = (SPVM::Int)$hash->get($keys->[$i]);
+      my $rhs = (SPVM::Int)$vals->[$i];
+      unless ($lhs->val == $rhs->val) {
         return 0;
-      };
+      }
+    }
+
+    # test keys
+    my $got_keys = $hash->keys;
+    my $lhs = new object [@$got_keys];
+    for (my $i = 0; $i < @$got_keys; $i++) {
+      $lhs->[$i] = $got_keys->[$i];
+    }
+    my $rhs = new object [@$keys];
+    for (my $i = 0; $i < @$keys; $i++) {
+      $rhs->[$i] = $keys->[$i];
+    }
+    my $strcmp = sub : int ($self : self, $lhs : object, $rhs : object) {
+      my $s = (string)$lhs;
+      my $t = (string)$rhs;
+      unless ($s eq $t) {
+        return 0;
+      }
+      return 1;
+    };
+    unless (_same_unordered_objects($lhs, $rhs, $strcmp)) {
+      return 0;
+    }
+
+    # test values
+    my $intcmp = sub : int ($self : self, $lhs : object, $rhs : object) {
+      my $x = (SPVM::Int)$lhs;
+      my $y = (SPVM::Int)$rhs;
+      unless ($x->val == $y->val) {
+        return 0;
+      }
+      return 1;
+    };
+    unless (_same_unordered_objects($hash->values, $vals, $intcmp)) {
+      return 0;
     }
     return 1;
   }

--- a/t/default/lib/TestCase/Hash.spvm
+++ b/t/default/lib/TestCase/Hash.spvm
@@ -1,6 +1,7 @@
 package TestCase::Hash {
   use SPVM::Int;
   use SPVM::Hash;
+  use SPVM::Comparator;
 
   sub test_murmur_hash : int () {
     my $seed = 123456789;
@@ -350,6 +351,32 @@ package TestCase::Hash {
     return 1;
   }
 
+  sub _same_unordered_objects : int ($lhs : object[], $rhs : object[], $comparator : SPVM::Comparator) {
+    unless (@$lhs == @$rhs) {
+      return 0;
+    }
+    my $rhs_used = new int [@$rhs];
+    for (my $i = 0; $i < @$lhs; ++$i) {
+      my $found = 0;
+      for (my $j = 0; $j < @$rhs; ++$j) {
+        if (!$rhs_used->[$j] && $comparator->compare($lhs->[$i], $rhs->[$j])) {
+          $found = 1;
+          $rhs_used->[$j] = 1;
+          last;
+        }
+      }
+      unless ($found) {
+        return 0;
+      }
+    }
+    for (my $i = 0; $i < @$rhs_used; $i++) {
+      unless ($rhs_used->[$i]) {
+        return 0;
+      }
+    }
+    return 1;
+  }
+
   sub test_keys : int () {
     my $hash = SPVM::Hash->new;
     my $keys = ["a", "bb", "12345"];
@@ -358,45 +385,41 @@ package TestCase::Hash {
       $hash->set($keys->[$i], $vals->[$i]);
     }
     my $got_keys = $hash->keys;
-    unless (@$got_keys == @$keys) {
-      return 0;
+    my $lhs = new object [@$got_keys];
+    for (my $i = 0; $i < @$got_keys; $i++) {
+      $lhs->[$i] = $got_keys->[$i];
     }
-    # cmp_deeply( $got_keys, bag(@$keys) );
-    for (my $i = 0; $i < @$got_keys; ++$i) {
-      my $found = 0;
-      for (my $j = 0; $j < @$keys; ++$j) {
-        if ($got_keys->[$i] eq $keys->[$j]) {
-          $found = 1;
-        }
-      }
-      unless ($found) {
+    my $rhs = new object [@$keys];
+    for (my $i = 0; $i < @$keys; $i++) {
+      $rhs->[$i] = $keys->[$i];
+    }
+    my $comparator = sub : int ($self : self, $lhs : object, $rhs : object) {
+      my $s = (string)$lhs;
+      my $t = (string)$rhs;
+      unless ($s eq $t) {
         return 0;
       }
-    }
-    return 1;
+      return 1;
+    };
+    return _same_unordered_objects($lhs, $rhs, $comparator);
   }
 
   sub test_values : int () {
     my $hash = SPVM::Hash->new;
     my $keys = ["a", "bb", "12345"];
-    my $vals = [SPVM::Int->new(1), SPVM::Int->new(1), SPVM::Int->new(9)];
+    my $vals = [(object) SPVM::Int->new(1), SPVM::Int->new(2), SPVM::Int->new(3)];
     for (my $i = 0; $i < @$keys; ++$i) {
       $hash->set($keys->[$i], $vals->[$i]);
     }
-    my $got_vals = $hash->values;
-    unless (@$got_vals == @$vals) {
-      return 0;
-    }
-    my $count_1 = 0;
-    my $count_9 = 0;
-    for (my $i = 0; $i < @$got_vals; ++$i) {
-      if (((SPVM::Int)$got_vals->[$i])->val == 1) { $count_1++; }
-      if (((SPVM::Int)$got_vals->[$i])->val == 9) { $count_9++; }
-    }
-    unless ($count_1 == 2 && $count_9 == 1) {
-      return 0;
-    }
-    return 1;
+    my $comparator = sub : int ($self : self, $lhs : object, $rhs : object) {
+      my $x = (SPVM::Int)$lhs;
+      my $y = (SPVM::Int)$rhs;
+      unless ($x->val == $y->val) {
+        return 0;
+      }
+      return 1;
+    };
+    return _same_unordered_objects($hash->values, $vals, $comparator);
   }
 
   sub test_many_hash_collisions : int () {


### PR DESCRIPTION
`SPVM::HashEntry` のフィールドの getter, setter を、関数からアクセサに変更するリファクタです。

本 PR には現状の master の上に、https://github.com/yuki-kimoto/SPVM/pull/32 のバグ修正が取り込まれております。
上記 PR のマージ後、本 PR のコミットを修正してマージできます。
