### PR TITLE
Add relaxed property and refactor SPVM::JSON

### DIFF
--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -94,7 +94,7 @@ package SPVM::JSON {
       unless ($s->[$$i] == $expected->[$$i - $begin]) {
         _croak_with_dump_remain("Expected token: $expected doesn't exist", $s, $i, $end);
       }
-      $$i++;
+      ++$$i;
       if ($$i - $begin == $length) {
         last;
       }
@@ -120,7 +120,7 @@ package SPVM::JSON {
     _expect_token($s, $i, $end, "\"");
     my $chars_length = $chars->length;
     my $value = new byte [$chars_length];
-    for (my $k = 0; $k < $chars_length; $k++) {
+    for (my $k = 0; $k < $chars_length; ++$k) {
       my $got = ((SPVM::Int)$chars->shift)->val;
       $value->[$k] = (byte)$got;
     }
@@ -134,7 +134,7 @@ package SPVM::JSON {
     my $has_sign = 0;
     my $decimal_stat = 0; # 0: '.' hasn't appeared yet. 1: '.' or 'e' has already appeared. 2: value is "0" or next char should be '.'
     if ($s->[$$i] == '-') {
-      $$i++;
+      ++$$i;
       $has_sign = 1;
     }
     if ($s->[$$i] == '0') {
@@ -344,7 +344,7 @@ package SPVM::JSON {
     }
     my $sum_length = $self->{indent_length} * $depth;
     my $indent_bytes = new byte [$sum_length];
-    for (my $i = 0; $i < $sum_length; $i++) {
+    for (my $i = 0; $i < $sum_length; ++$i) {
       $indent_bytes->[$i] = ' ';
     }
     return (string)$indent_bytes;
@@ -352,7 +352,7 @@ package SPVM::JSON {
 
   # TODO: Use separated sort function from this module
   sub _sort_keys : void ($keys : string[]) {
-    for (my $i = 0; $i < @$keys - 1; $i++) {
+    for (my $i = 0; $i < @$keys - 1; ++$i) {
       for (my $j = @$keys - 1; $j > $i; $j--) {
         if ($keys->[$j - 1] gt $keys->[$j]) {
           my $temp = $keys->[$j - 1];
@@ -382,7 +382,7 @@ package SPVM::JSON {
       if ($self->{canonical}) {
         _sort_keys($keys); # TODO: Use separated sort function from this module
       }
-      for (my $i = 0; $i < @$keys; $i++) {
+      for (my $i = 0; $i < @$keys; ++$i) {
         if ($i > 0) {
           $text .= ",";
           if ($self->{indent}) {
@@ -423,7 +423,7 @@ package SPVM::JSON {
       }
       my $list = (SPVM::List)$o;
       my $length = $list->length;
-      for (my $i = 0; $i < $length; $i++) {
+      for (my $i = 0; $i < $length; ++$i) {
         if ($i > 0) {
           $text .= ",";
           if ($self->{indent}) {

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -57,7 +57,6 @@ package SPVM::JSON {
   }
 
   sub _decode_string : string ($self : self, $s : string, $i : int&, $end : int) {
-    # TODO: change better way to substr
     my $chars = SPVM::List->new;
     _expect_token($s, $i, $end, "\"");
     while (1) { 

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -11,43 +11,88 @@ package SPVM::JSON {
   has space_before : public int;
   has space_after : public int;
   has canonical : public int;
+  has relaxed : public int;
 
-  sub _skip_spaces : void ($s : string, $i : int&, $end : int) {
-    while (1) {
+  sub _croak_with_dump_remain : void ($croak_message : string, $s : string, $i : int&, $end : int) {
+    my $remain = new byte [$end - $$i];
+    for (my $k = 0; $k < $end - $$i; ++$k) {
+      $remain->[$k] = $s->[$$i + $k];
+    }
+    croak $croak_message . "\nRemains... '" . (string)$remain . "'";
+  }
+
+  sub _skip_comment : void ($s : string, $i : int&, $end : int) {
+    my $comment = 0;
+    for (; $$i < $end ; ++$$i) {
+      if ($comment == 1 && $s->[$$i] == '\n') {
+        return;
+      }
+      if ($comment == 2) {
+        unless ($s->[$$i] == '*') {
+          next;
+        }
+        ++$$i;
+        unless ($$i < $end) {
+          return; # no */ is allowed
+        }
+        if ($s->[$$i] == '/') {
+          $comment = 0;
+        }
+      }
+      elsif ($s->[$$i] == '#') {
+        $comment = 1;
+      }
+      elsif ($s->[$$i] == '/') {
+        ++$$i;
+        unless ($$i < $end) {
+          _croak_with_dump_remain("Unexpected token '/'", $s, $i, $end);
+        }
+        if ($s->[$$i] == '/') {
+          $comment = 1;
+        }
+        elsif ($s->[$$i] == '*') {
+          $comment = 2;
+        }
+        else {
+          _croak_with_dump_remain("Unexpected token '/'", $s, $i, $end);
+        }
+      }
+      elsif ($comment == 0) {
+        return;
+      }
+    }
+  }
+
+  sub _skip_spaces : void ($self : self, $s : string, $i : int&, $end : int) {
+    for (; 1 ; ++$$i) {
+      if ($self->{relaxed}) {
+        _skip_comment($s, $i, $end);
+      }
       if ($$i == $end) {
         return;
       }
       unless ($s->[$$i] == ' ' || $s->[$$i] == '\n' || $s->[$$i] == '\t' || $s->[$$i] == '\r') {
         last;
       }
-      $$i++;
     }
   }
 
-  sub _skip_spaces_at_not_end : void ($s : string, $i : int&, $end : int) {
-    _skip_spaces($s, $i, $end);
+  sub _skip_spaces_at_not_end : void ($self : self, $s : string, $i : int&, $end : int) {
+    $self->_skip_spaces($s, $i, $end);
     if ($$i == $end) {
-      croak "Incomplete hash";
+      _croak_with_dump_remain("Incomplete JSON", $s, $i, $end);
     }
-  }
-
-  sub _dump_remain : string ($s : string, $i : int&, $end : int) {
-    my $remain = "";
-    for (my $k = $$i; $k < $end; $k++) {
-      $remain .= $s->[$k];
-    }
-    return $remain;
   }
 
   sub _expect_token : void ($s : string, $i : int&, $end : int, $expected : string) {
     my $length = length $expected;
     unless ($$i + $length <= $end) {
-      croak "Expected token: $expected doesn't exist";
+      _croak_with_dump_remain("Expected token: $expected doesn't exist", $s, $i, $end);
     }
     my $begin = $$i;
     while (1) {
       unless ($s->[$$i] == $expected->[$$i - $begin]) {
-        croak "Expected token: $expected doesn't exist";
+        _croak_with_dump_remain("Expected token: $expected doesn't exist", $s, $i, $end);
       }
       $$i++;
       if ($$i - $begin == $length) {
@@ -63,11 +108,14 @@ package SPVM::JSON {
       if ($$i >= $end || $s->[$$i] == '"') {
         last;
       }
+      if (!$self->{relaxed} && $s->[$$i] == '\t') {
+        _croak_with_dump_remain("Literal ASCII tab characters are not allowed in string", $s, $i, $end);
+      }
       $chars->push(SPVM::Int->new($s->[$$i]));
       ++$$i;
     }
     if ($$i == $end) {
-      croak "Invalid string. end-quote doesn't exist";
+      _croak_with_dump_remain("Invalid string. end-quote doesn't exist", $s, $i, $end);
     }
     _expect_token($s, $i, $end, "\"");
     my $chars_length = $chars->length;
@@ -97,15 +145,15 @@ package SPVM::JSON {
     while ($$i < $end) {
       if ($s->[$$i] == '.') {
         if ($decimal_stat == 1) {
-          croak "Invalid digits: Dot should appear at most once";
+          _croak_with_dump_remain("Invalid digits: Dot should appear at most once", $s, $i, $end);
         }
         unless ($has_digit) {
-          croak "Invalid digits: Not found digits before dot";
+          _croak_with_dump_remain("Invalid digits: Not found digits before dot", $s, $i, $end);
         }
         $decimal_stat = 1;
         ++$$i;
         unless ($$i < $end && '0' <= $s->[$$i] && $s->[$$i] <= '9') {
-          croak "Invalid digits: Not found digits after dot";
+          _croak_with_dump_remain("Invalid digits: Not found digits after dot", $s, $i, $end);
         }
         $digits *= 10;
         $digits += $s->[$$i++] - '0';
@@ -131,7 +179,7 @@ package SPVM::JSON {
         ++$$i;
         $decimal_stat = 1;
         unless ($$i < $end && ($s->[$$i] == '+') || ($s->[$$i] == '-')) {
-          croak "Invalid digits: '+' or '-' is expected after 'e'";
+          _croak_with_dump_remain("Invalid digits: '+' or '-' is expected after 'e'", $s, $i, $end);
         }
         my $side : int; # -1: "e+XX", +1: "e-XX"
         if ($s->[$$i++] == '+') {
@@ -141,7 +189,7 @@ package SPVM::JSON {
           $side = +1;
         }
         unless ($$i < $end && '0' <= $s->[$$i] && $s->[$$i] <= '9') {
-          croak "Invalid digits: digits should exist after 'e'";
+          _croak_with_dump_remain("Invalid digits: digits should exist after 'e'", $s, $i, $end);
         }
         my $exp = $s->[$$i++] - '0';
         while ($$i < $end && '0' <= $s->[$$i] && $s->[$$i] <= '9') {
@@ -157,7 +205,7 @@ package SPVM::JSON {
     }
 
     unless ($has_digit) {
-      croak "Invalid digits: Not found digits after '-'";
+      _croak_with_dump_remain("Invalid digits: Not found digits after '-'", $s, $i, $end);
     }
     if ($decimal_stat == 1) {
       my $value = (double) $digits / pow(10, $offset);
@@ -198,7 +246,7 @@ package SPVM::JSON {
     _expect_token($s, $i, $end, "{");
     while (1) {
       # end of hash
-      _skip_spaces_at_not_end($s, $i, $end);
+      $self->_skip_spaces_at_not_end($s, $i, $end);
       if ($s->[$$i] == '}') {
         last;
       }
@@ -206,7 +254,11 @@ package SPVM::JSON {
       # comma
       if ($has_element) {
         _expect_token($s, $i, $end, ",");
-        _skip_spaces_at_not_end($s, $i, $end);
+        $self->_skip_spaces_at_not_end($s, $i, $end);
+        # allow last comma
+        if ($self->{relaxed} && $s->[$$i] == '}') {
+          last;
+        }
       }
       else {
         $has_element = 1;
@@ -216,11 +268,11 @@ package SPVM::JSON {
       my $key = $self->_decode_string($s, $i, $end);
 
       # separator
-      _skip_spaces_at_not_end($s, $i, $end);
+      $self->_skip_spaces_at_not_end($s, $i, $end);
       _expect_token($s, $i, $end, ":");
 
       # value
-      _skip_spaces_at_not_end($s, $i, $end);
+      $self->_skip_spaces_at_not_end($s, $i, $end);
       $hash->set($key, $self->_decode_value($s, $i, $end));
     }
     _expect_token($s, $i, $end, "}");
@@ -233,7 +285,7 @@ package SPVM::JSON {
     my $has_element = 0;
     while (1) {
       # end of list
-      _skip_spaces_at_not_end($s, $i, $end);
+      $self->_skip_spaces_at_not_end($s, $i, $end);
       if ($s->[$$i] == ']') {
         last;
       }
@@ -241,7 +293,11 @@ package SPVM::JSON {
       # comma
       if ($has_element) {
         _expect_token($s, $i, $end, ",");
-        _skip_spaces_at_not_end($s, $i, $end);
+        $self->_skip_spaces_at_not_end($s, $i, $end);
+        # allow last comma
+        if ($self->{relaxed} && $s->[$$i] == ']') {
+          last;
+        }
       }
       else {
         $has_element = 1;
@@ -254,7 +310,7 @@ package SPVM::JSON {
 
   sub _decode_value : object ($self : self, $s : string, $i : int&, $end : int) {
     # objects
-    _skip_spaces_at_not_end($s, $i, $end);
+    $self->_skip_spaces_at_not_end($s, $i, $end);
     if ($s->[$$i] == '{') {
       return $self->_decode_hash($s, $i, $end);
     }
@@ -278,7 +334,7 @@ package SPVM::JSON {
 
     # unknown token
     else {
-      croak "Unexpected token. Remains... '" . _dump_remain($s, $i, $end) . "'";
+      _croak_with_dump_remain("Unexpected token. ", $s, $i, $end);
     }
   }
 
@@ -421,6 +477,7 @@ package SPVM::JSON {
     $json->{indent_length} = 0;
     $json->{space_before} = 0;
     $json->{space_after} = 0;
+    $json->{relaxed} = 1;
     return $json;
   }
 
@@ -434,12 +491,12 @@ package SPVM::JSON {
   sub decode : object ($self : self, $json_text : string) {
     my $length = length $json_text;
     my $iter = 0;
-    _skip_spaces($json_text, \$iter, $length);
+    $self->_skip_spaces($json_text, \$iter, $length);
     if ($iter == $length) {
       return undef;
     }
     my $ret = $self->_decode_value($json_text, \$iter, $length);
-    _skip_spaces($json_text, \$iter, $length);
+    $self->_skip_spaces($json_text, \$iter, $length);
     unless ($iter == $length) {
       croak "Not all json_text is decoded yet. Remains at $iter";
     }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -314,7 +314,7 @@ package SPVM::JSON {
       my $text = "";
       if ($self->{indent}) {
         my $indent = $self->_make_indent($depth);
-        unless ($indent eq "") { # FIXME: 空文字連結
+        unless ($indent eq "") {
           $text .= $indent;
         }
       }
@@ -353,7 +353,7 @@ package SPVM::JSON {
       if ($self->{indent}) {
         $text .= "\n";
         my $indent = $self->_make_indent($depth);
-        unless ($indent eq "") { # FIXME: 空文字連結
+        unless ($indent eq "") {
           $text .= $indent;
         }
       }
@@ -383,7 +383,7 @@ package SPVM::JSON {
       if ($self->{indent}) {
         $text .= "\n";
         my $indent = $self->_make_indent($depth);
-        unless ($indent eq "") { # FIXME: 空文字連結
+        unless ($indent eq "") {
           $text .= $indent;
         }
       }
@@ -395,7 +395,7 @@ package SPVM::JSON {
       return "\"" . (string)$o . "\"";
     }
     elsif ($o isa SPVM::Int) {
-      return (string)(((SPVM::Int)$o)->val); # FIXME: (string)のキャストを外したときのエラー: "." operater right value must be defined
+      return (string)(((SPVM::Int)$o)->val);
     }
     elsif ($o isa SPVM::Long) {
       return (string)(((SPVM::Long)$o)->val);

--- a/t/default/lib-SPVM-JSON.t
+++ b/t/default/lib-SPVM-JSON.t
@@ -22,6 +22,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   # [TODO]Failed tests
   # ok(TestCase::JSON->test_digits_double);
   
+  ok(TestCase::JSON->test_root_is_primitive);
   ok(TestCase::JSON->test_nest_object);
   ok(TestCase::JSON->test_spaces);
   ok(TestCase::JSON->test_format_name_separator);

--- a/t/default/lib-SPVM-JSON.t
+++ b/t/default/lib-SPVM-JSON.t
@@ -28,6 +28,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->test_format_name_separator);
   ok(TestCase::JSON->test_format_indent);
   ok(TestCase::JSON->test_format_pretty);
+  ok(TestCase::JSON->test_relaxed);
 }
 
 

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -5,112 +5,14 @@ package TestCase::JSON {
   use SPVM::Double;
   use SPVM::JSON::Bool;
 
-  # TODO: Extract pre_object_equals, _hash_equals and _list_equals as test utilities, something like Test::More::is_deeply
-  sub _object_equals : int ($lhs : object, $rhs : object) {
-    if ($lhs isa SPVM::Hash) {
-      unless ($rhs isa SPVM::Hash) {
-        return 0;
-      }
-      my $x = (SPVM::Hash)$lhs;
-      my $y = (SPVM::Hash)$rhs;
-      unless (_hash_equals($x, $y)) {
-        return 0;
-      }
-    }
-    elsif ($lhs isa SPVM::List) {
-      unless ($rhs isa SPVM::List) {
-        return 0;
-      }
-      my $x = (SPVM::List)$lhs;
-      my $y = (SPVM::List)$rhs;
-      unless (_list_equals($x, $y)) {
-        return 0;
-      }
-    }
-    elsif ($lhs isa SPVM::Int) {
-      unless ($rhs isa SPVM::Int) {
-        return 0;
-      }
-      my $x = (SPVM::Int)$lhs;
-      my $y = (SPVM::Int)$rhs;
-      unless ($x->val == $y->val) {
-        return 0;
-      }
-    }
-    elsif ($lhs isa SPVM::Long) {
-      unless ($rhs isa SPVM::Long) {
-        return 0;
-      }
-      my $x = (SPVM::Long)$lhs;
-      my $y = (SPVM::Long)$rhs;
-      unless ($x->val == $y->val) {
-        return 0;
-      }
-    }
-    elsif ($lhs isa SPVM::Double) {
-      unless ($rhs isa SPVM::Double) {
-        return 0;
-      }
-      my $x = (SPVM::Double)$lhs;
-      my $y = (SPVM::Double)$rhs;
-      unless ($x->val == $y->val) {
-        warn("lhs: " . $x->val . " rhs: " . $y->val);
-        return 0;
-      }
-    }
-    elsif ($lhs isa SPVM::JSON::Bool) {
-      unless ($rhs isa SPVM::JSON::Bool) {
-        return 0;
-      }
-      my $x = (SPVM::JSON::Bool)$lhs;
-      my $y = (SPVM::JSON::Bool)$rhs;
-      unless ($x->val == $y->val) {
-        return 0;
-      }
-    }
-    elsif ($lhs isa string) {
-      unless ($rhs isa string) {
-        return 0;
-      }
-      my $x = (string)$lhs;
-      my $y = (string)$rhs;
-      unless ($x eq $y) {
-        return 0;
-      }
-    }
-    else {
-      warn("typename mismatch. lhs: " . type_name($lhs) . ", rhs: " . type_name($rhs));
-      return 0;
-    }
-    return 1;
+  our $DEFAULT_JSON : SPVM::JSON;
+
+  BEGIN {
+    $DEFAULT_JSON = SPVM::JSON->new;
+    $DEFAULT_JSON->{canonical} = 1;
   }
 
-  sub _hash_equals : int ($lhs : SPVM::Hash, $rhs : SPVM::Hash) {
-    my $targets = [$lhs, $rhs];
-    for (my $i = 0; $i < 2; $i++) {
-      my $keys = $targets->[$i]->keys;
-      for (my $j = 0; $j < @$keys; $j++) {
-        unless (_object_equals($targets->[1 - $i]->get($keys->[$j]), $targets->[$i]->get($keys->[$j]))) {
-          return 0;
-        }
-      }
-    }
-    return 1;
-  }
-
-  sub _list_equals : int ($lhs : SPVM::List, $rhs : SPVM::List) {
-    unless ($lhs->length == $rhs->length) {
-      return 0;
-    }
-    for (my $i = 0; $i < $lhs->length; $i++) {
-      unless (_object_equals($lhs->get($i), $rhs->get($i))) {
-        return 0;
-      }
-    }
-    return 1;
-  }
-
-  sub _validate_json_text_strictly : int ($json : SPVM::JSON, $input : string[], $expected : string[]) {
+  sub _validate : int ($json : SPVM::JSON, $input : string[], $expected : string[]) {
     for (my $i = 0; $i < @$input; $i++) {
       my $decoded = $json->decode($input->[$i]);
       my $actual = $json->encode($decoded);
@@ -122,27 +24,7 @@ package TestCase::JSON {
     return 1;
   }
 
-  sub _validate : int ($json : SPVM::JSON, $json_texts : string[], $objects : object[]) {
-    unless (@$json_texts == @$objects) {
-      croak "testcase json_texts and objects lengths are mismatch"; # FIXME: Invalid escape character in string literal at t/default/lib/TestCase/JSON.spvm line 115
-    }
-    for (my $i = 0; $i < @$json_texts; $i++) {
-      my $decoded = $json->decode($json_texts->[$i]);
-      unless (_object_equals($decoded, $objects->[$i])) {
-        return 0;
-      }
-      # decode() returns valid object, and then check encode().
-      my $encoded = $json->encode($decoded);
-      my $restructured = $json->decode($encoded);
-      unless (_object_equals($restructured, $objects->[$i])) {
-        return 0;
-      }
-    }
-    return 1;
-  }
-
   sub test_empty : int () {
-    my $json = SPVM::JSON->new;
     my $input = [
       # empty
       "",
@@ -152,140 +34,61 @@ package TestCase::JSON {
       " \r\n\t  \r\r\t\t\n "
     ];
     my $expected = ["", "", "", "", "", ""];
-    return _validate_json_text_strictly($json, $input, $expected);
+    return _validate($DEFAULT_JSON, $input, $expected);
   }
 
   sub test_flat_hash : int () {
-    my $json_texts = ["{}", "{\"digit\":42}", "{\"string\":\"vstr\"}", "{\"double\":0.123}", "{\"bool_true\":true}", "{\"bool_false\":false}", "{\"a\":1,\"A\":0.1,\"ABC\":false,\"qwerty\":\"asdfg\"}"];
-    my $objects = [(object)
-      SPVM::Hash->new_with_array(new object [0]),
-      SPVM::Hash->new_with_array([(object) "digit",SPVM::Int->new(42)]),
-      SPVM::Hash->new_with_array([(object) "string","vstr"]),
-      SPVM::Hash->new_with_array([(object) "double",SPVM::Double->new(0.123)]),
-      SPVM::Hash->new_with_array([(object) "bool_true",SPVM::JSON::Bool->TRUE]),
-      SPVM::Hash->new_with_array([(object) "bool_false",SPVM::JSON::Bool->FALSE]),
-      SPVM::Hash->new_with_array([(object) "a",SPVM::Int->new(1),"A",SPVM::Double->new(0.1),"ABC",SPVM::JSON::Bool->FALSE,"qwerty","asdfg"])
-    ];
-    return _validate(SPVM::JSON->new, $json_texts, $objects);
+    my $json_texts = ["{}", "{\"digit\":42}", "{\"string\":\"vstr\"}", "{\"double\":0.123}", "{\"bool_true\":true}", "{\"bool_false\":false}", "{\"A\":0.1,\"ABC\":false,\"a\":1,\"qwerty\":\"asdfg\"}"];
+    return _validate($DEFAULT_JSON, $json_texts, $json_texts);
   }
 
   sub test_flat_list : int () {
     my $json_texts = ["[]", "[1,2,3]", "[\"abc\",\"123\"]", "[123,\"abc\",0,\"123abc\",3.1415]"];
-    my $objects = [(object)
-      SPVM::List->new_with_array(new object [0]),
-      SPVM::List->new_with_array([(object) SPVM::Int->new(1), SPVM::Int->new(2), SPVM::Int->new(3)]),
-      SPVM::List->new_with_array([(object) "abc", "123"]),
-      SPVM::List->new_with_array([(object) SPVM::Int->new(123), "abc", SPVM::Int->new(0), "123abc", SPVM::Double->new(3.1415)])
-    ];
-    return _validate(SPVM::JSON->new, $json_texts, $objects);
+    return _validate($DEFAULT_JSON, $json_texts, $json_texts);
   }
 
   sub test_digits_int : int () {
     my $json_texts = ["[0,1,-1]"];
-    my $objects = [(object)
-      SPVM::List->new_with_array([(object)
-        SPVM::Int->new(0),
-        SPVM::Int->new(1),
-        SPVM::Int->new(-1)
-      ]),
-    ];
-    return _validate(SPVM::JSON->new, $json_texts, $objects);
+    return _validate($DEFAULT_JSON, $json_texts, $json_texts);
   }
 
   sub test_digits_long : int () {
     my $json_texts = ["[100000000000,-100000000000]"];
-    my $objects = [(object)
-      SPVM::List->new_with_array([(object)
-        SPVM::Long->new(100000000000L),
-        SPVM::Long->new(-100000000000L)
-      ]),
-    ];
-    return _validate(SPVM::JSON->new, $json_texts, $objects);
+    return _validate($DEFAULT_JSON, $json_texts, $json_texts);
   }
 
   sub test_digits_double : int () {
     my $json_texts = ["[0.123,-0.123,3.14,-3.14,123.987,-123.987,1.23456e+1,1.23456e-1,1.23456e+08,1.23456e-08,1.23456e+008,1.23456e-008,1.23456e+018,1.23456e-018,9.9e-100,9.9e+300,-1.23e+123]"];
-    my $objects = [(object)
-      SPVM::List->new_with_array([(object)
-        SPVM::Double->new(0.123),
-        SPVM::Double->new(-0.123),
-        SPVM::Double->new(3.14),
-        SPVM::Double->new(-3.14),
-        SPVM::Double->new(123.987),
-        SPVM::Double->new(-123.987),
-        SPVM::Double->new(1.23456e+1),
-        SPVM::Double->new(1.23456e-1),
-        SPVM::Double->new(1.23456e+08),
-        SPVM::Double->new(1.23456e-08),
-        SPVM::Double->new(1.23456e+008),
-        SPVM::Double->new(1.23456e-008),
-        SPVM::Double->new(1.23456e+018),
-        SPVM::Double->new(1.23456e-018),
-        SPVM::Double->new(9.9e-100),
-        SPVM::Double->new(9.9e+300),
-        SPVM::Double->new(-1.23e+123)
-      ])
-    ];
-    return _validate(SPVM::JSON->new, $json_texts, $objects);
+    return _validate($DEFAULT_JSON, $json_texts, $json_texts);
+  }
+
+  sub test_root_is_primitive : int () {
+    my $json_texts = ["\"abc\"", "123", "true"];
+    return _validate($DEFAULT_JSON, $json_texts, $json_texts);
   }
 
   sub test_nest_object : int () {
     my $json_texts = [
-        "{\"A\":{\"B\":1,\"C\":{\"D\":0.1,\"E\":true,\"F\":\"str\",\"G\":[\"elem\",\"ents\",{\"key\":\"value\"}]}},\"end\":\"eof\"}"
+      "{\"A\":{\"B\":1,\"C\":{\"D\":0.1,\"E\":true,\"F\":\"str\",\"G\":[\"elem\",\"ents\",{\"key\":\"value\"}]}},\"end\":\"eof\"}"
     ];
-    my $objects = [(object)
-      SPVM::Hash->new_with_array([(object)
-        "A", SPVM::Hash->new_with_array([(object)
-          "B", SPVM::Int->new(1),
-          "C", SPVM::Hash->new_with_array([(object)
-            "D", SPVM::Double->new(0.1),
-            "E", SPVM::JSON::Bool->TRUE,
-            "F", "str",
-            "G", SPVM::List->new_with_array([(object)
-              "elem", "ents",
-              SPVM::Hash->new_with_array([(object)
-                "key", "value"
-              ])
-            ])
-          ])
-        ]),
-        "end", "eof"
-      ])
-    ];
-
-    my $json = SPVM::JSON->new;
-    unless (_validate($json, $json_texts, $objects)) {
-      return 0;
-    }
-    # test canonical hash encoding
-    $json->{canonical} = 1;
-    unless (_validate_json_text_strictly($json, $json_texts, $json_texts)) {
+    unless (_validate($DEFAULT_JSON, $json_texts, $json_texts)) {
       return 0;
     }
     return 1;
   }
 
   sub test_spaces : int () {
-    my $json_texts = [
+    my $inputs = [
       # Root type is "hash"
       " { \"key\" \n\t: 123\t,\n\t\t\"list\" :\n[\t1\t,\r2\t,\t3\n]}\r\r",
       # Root type is "list"
       " [ 1, 3.14\n, true \t , \"a\" ] " # primitives: Int, Double, Bool, string
     ];
-    my $objects = [(object)
-      # Root type is "hash"
-      SPVM::Hash->new_with_array([(object)
-        "key", SPVM::Int->new(123),
-        "list", SPVM::List->new_with_array([(object)
-          SPVM::Int->new(1), SPVM::Int->new(2), SPVM::Int->new(3)
-        ])
-      ]),
-      # Root type is "list"
-      SPVM::List->new_with_array([(object)
-        SPVM::Int->new(1), SPVM::Double->new(3.14), SPVM::JSON::Bool->TRUE, "a"
-      ])
+    my $outputs = [
+      "{\"key\":123,\"list\":[1,2,3]}",
+      "[1,3.14,true,\"a\"]"
     ];
-    return _validate(SPVM::JSON->new, $json_texts, $objects);
+    return _validate($DEFAULT_JSON, $inputs, $outputs);
   }
 
   sub test_format_name_separator : int () {

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -152,4 +152,25 @@ package TestCase::JSON {
     }
     return 1;
   }
+
+  sub test_relaxed : int () {
+    my $inputs  = ["{\"k\":1,}","[1,]","{\"a\":1# comment\n,\"b\":2, ##\n\"c\":3,//xyz\n\"d\" /*multiple\ncomments//x#y*\nz*/:4}","\"\t\""];
+    my $outputs = ["{\"k\":1}","[1]","{\"a\":1,\"b\":2,\"c\":3,\"d\":4}","\"\t\""];
+    my $json = SPVM::JSON->new;
+    $json->{relaxed} = 1;
+    unless (_validate($DEFAULT_JSON, $inputs, $outputs)) {
+      return 0;
+    }
+    $json->{relaxed} = 0;
+    for (my $i = 0; $i < @$inputs; $i++) {
+      eval {
+        $json->encode($json->decode($inputs->[$i]));
+      }
+      unless ($@) {
+        return 0;
+      }
+      $@ = undef;
+    }
+    return 1;
+  }
 }


### PR DESCRIPTION
#34

- ルートが primitive のときのテストを追加

- **relaxed** の実装 (cite: https://metacpan.org/pod/JSON::PP#relaxed)
  - list (hash) items can have an end-comma
  - shell-style '#'-comments
  - C++-style one-line '//'-comments
  - literal ASCII TAB characters in strings

- テストで出力を `canonical` に強制して単純化