### PR TITLE
use _MSC_VER instead of _WIN32 because __declspec is Microsoft specific

### DIFF
--- a/lib/SPVM/Builder/include/spvm_utf8proc.h
+++ b/lib/SPVM/Builder/include/spvm_utf8proc.h
@@ -123,7 +123,7 @@ typedef bool spvm_utf8proc_bool;
 #ifdef SPVM_UTF8PROC_STATIC
 #  define SPVM_UTF8PROC_DLLEXPORT
 #else
-#  ifdef _WIN32
+#  ifdef _MSC_VER
 #    ifdef SPVM_UTF8PROC_EXPORTS
 #      define SPVM_UTF8PROC_DLLEXPORT __declspec(dllexport)
 #    else


### PR DESCRIPTION
`__declspec` が Microsoft 固有の仕様であるため `_WIN32` の代わりに `_MSC_VER` を使用します。
変更動機は AppVeyor の CI 上で `spvm_utf8proc.c` をコンパイルするためです。
変更が正しいかどうか、ご確認頂けますでしょうか 🙇 

以下のようなエラーを回避する目的
```
gcc -c   -s -O2 -DWIN32 -DWIN64 -DCONSERVATIVE -D__USE_MINGW_ANSI_STDIO -DPERL_TEXTMODE_SCRIPTS -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -DUSE_PERLIO -fwrapv -fno-strict-aliasing -mms-bitfields -IC:/projects/spvm-doxdv/lib/SPVM/Builder/include -IC:/projects/spvm-doxdv/lib -std=c99 -O3   -DVERSION=\"0.0415\" -DXS_VERSION=\"0.0415\"  "-IC:\STRAWB~1\perl\lib\CORE"  -o lib/SPVM/Builder/src/spvm_utf8proc.o lib/SPVM/Builder/src/spvm_utf8proc.c
lib/SPVM/Builder/src/spvm_utf8proc.c:56:52: error: variable 'spvm_utf8proc_utf8class' definition is marked dllimport
 SPVM_UTF8PROC_DLLEXPORT const spvm_utf8proc_int8_t spvm_utf8proc_utf8class[256] = {
                                                    ^~~~~~~~~~~~~~~~~~~~~~~
lib/SPVM/Builder/src/spvm_utf8proc.c:56:52: warning: 'spvm_utf8proc_utf8class' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
gmake: *** [Makefile:574: lib/SPVM/Builder/src/spvm_utf8proc.o] Error 1
```

CIのログ: https://ci.appveyor.com/project/motxx/spvm-doxdv/builds/22306664

参考にしたもの
- [difference between gcc and vc](http://herumi.in.coocan.jp/prog/gcc-and-vc.html)
- [Fix "redeclared without dllimport attribute..." warning for MinGW by ark0f · Pull Request #2433 · pocoproject/poco · GitHub](https://github.com/pocoproject/poco/pull/2433)
- [_WIN32 vs. _MSC_VER · Issue #224 · osmcode/libosmium · GitHub](https://github.com/osmcode/libosmium/issues/224)