### PR TITLE
[WIP] Support AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+cache:
+- C:\strawberry
+
+install:
+- if not exist "C:\strawberry" choco install strawberryperl -y
+- set PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
+- cd %APPVEYOR_BUILD_FOLDER%
+- cpanm --quiet --installdeps --with-develop --notest .
+
+build_script:
+- perl Makefile.PL
+- gmake
+
+test_script:
+- gmake test

--- a/lib/SPVM/Builder/include/spvm_utf8proc.h
+++ b/lib/SPVM/Builder/include/spvm_utf8proc.h
@@ -123,7 +123,7 @@ typedef bool spvm_utf8proc_bool;
 #ifdef SPVM_UTF8PROC_STATIC
 #  define SPVM_UTF8PROC_DLLEXPORT
 #else
-#  ifdef _WIN32
+#  ifdef _MSC_VER
 #    ifdef SPVM_UTF8PROC_EXPORTS
 #      define SPVM_UTF8PROC_DLLEXPORT __declspec(dllexport)
 #    else


### PR DESCRIPTION
Windows 環境でテストをするために AppVeyor を導入します。

- テスト実行例
  - https://ci.appveyor.com/project/motxx/spvm-doxdv/builds/22309159

- WIP
  - IO 周りのテストで落ちてしまうようで、CIの設定の問題な気がするので調査中です。

- 備考
  - CI の導入により、Windows 環境で JSON の double のテストが落ちる場合があることを確認したので、別途修正予定です。