### PR TITLE
add SPVM::HTTP::URL modules

### DIFF
--- a/lib/SPVM/HTTP/URL.spvm
+++ b/lib/SPVM/HTTP/URL.spvm
@@ -136,7 +136,7 @@ package SPVM::HTTP::URL {
     $self->parse_fragment($url, $next);
   }
 
-  sub new : SPVM::HTTP::URL () {
+  sub parse : SPVM::HTTP::URL ($url : string) {
     my $self = new SPVM::HTTP::URL;
     $self->{scheme} = "";
     $self->{host} = "";
@@ -144,11 +144,6 @@ package SPVM::HTTP::URL {
     $self->{path} = "";
     $self->{params} = SPVM::HTTP::URL::Parameters->new();
     $self->{fragment} = "";
-    return $self;
-  }
-
-  sub parse : SPVM::HTTP::URL ($url : string) {
-    my $self = SPVM::HTTP::URL->new;
     $self->parse_url($url);
     return $self;
   }

--- a/lib/SPVM/HTTP/URL.spvm
+++ b/lib/SPVM/HTTP/URL.spvm
@@ -67,14 +67,21 @@ package SPVM::HTTP::URL {
     unless ($start < $length && $url->[$start] == '/') {
       return $start;
     }
+    $self->{path} = "/";
+    ++$start;
     for (my $i = $start; $i < $length; ++$i) {
-      if ($url->[$i] == '?' ||
+      if ($url->[$i] == '/') {
+        $self->{path} .= SPVM::HTTP::URL::Escape->unescape(
+            sliceb((byte [])$url, $start, $i - $start)) . "/";
+        $start = $i + 1;
+      }
+      elsif ($url->[$i] == '?' ||
           $url->[$i] == '#') {
-        $self->{path} = sliceb((byte [])$url, $start, $i - $start);
+        $self->{path} .= SPVM::HTTP::URL::Escape->unescape(
+            sliceb((byte [])$url, $start, $i - $start));
         return $i;
       }
     }
-    $self->{path} = sliceb((byte [])$url, $start, $length - $start);
     return $length;
   }
 
@@ -102,6 +109,7 @@ package SPVM::HTTP::URL {
     unless ($url->[$start] == '#') {
       return;
     }
+    # https://stackoverflow.com/questions/2849756/list-of-valid-characters-for-the-fragment-identifier-in-an-url
     $self->{fragment} = SPVM::HTTP::URL::Escape->unescape(
         sliceb((byte [])$url, $start + 1, $length - $start - 1));
   }
@@ -149,7 +157,7 @@ package SPVM::HTTP::URL {
     }
     $url .= $self->{path};
     if (@{$self->{params}->keys}) {
-      $url .= "?" . $self->{params}->escape();
+      $url .= "?" . $self->{params}->to_str;
     }
     if (length($self->{fragment})) {
       $url .= "#" . SPVM::HTTP::URL::Escape->escape($self->{fragment});

--- a/lib/SPVM/HTTP/URL.spvm
+++ b/lib/SPVM/HTTP/URL.spvm
@@ -1,0 +1,179 @@
+package SPVM::HTTP::URL {
+  use SPVM::HTTP::URL::Escape;
+  use SPVM::HTTP::URL::Parameters;
+
+  # [scheme:][//[host][/path][?query][#fragment]
+  has scheme    : public string;
+  has host      : public string;
+  has port      : public int;
+  has path      : public string;
+  has params    : public SPVM::HTTP::URL::Parameters;
+  has fragment  : public string;
+
+  private sub parse_scheme : int ($self : self, $url : string) {
+    my $length = length $url;
+    for (my $i = 0; $i < $length; ++$i) {
+      if ($url->[$i] == ':') {
+        $self->{scheme} = sliceb((byte [])$url, 0, $i);
+        return $i + 1;
+      }
+    }
+    croak "Cannot parse scheme: not found ':'";
+  }
+
+  private sub parse_host : int ($self : self, $url : string, $start : int) {
+    my $length = length $url;
+    unless ($start + 2 < $length &&
+        $url->[$start] == '/' && $url->[$start + 1] == '/') {
+      croak "Cannot parse host: requires \"//\"";
+    }
+    $start += 2;
+    for (my $i = $start; $i < $length; ++$i) {
+      if ($url->[$i] == '/' ||
+          $url->[$i] == '?' ||
+          $url->[$i] == '#') {
+        $self->{host} = sliceb((byte [])$url, $start, $i - $start);
+        return $i;
+      } elsif ($url->[$i] == ':') {
+        $self->{host} = sliceb((byte [])$url, $start, $i - $start);
+        return $self->parse_port($url, $i + 1);
+      }
+    }
+    $self->{host} = sliceb((byte [])$url, $start, $length - $start);
+    return $length;
+  }
+
+  private sub parse_port : int ($self : self, $url : string, $start : int) {
+    my $length = length $url;
+    my $port = 0;
+    for (my $i = $start; $i < $length; ++$i) {
+      if ($url->[$i] == '/' ||
+          $url->[$i] == '?' ||
+          $url->[$i] == '#') {
+        $self->{port} = $port;
+        return $i;
+      } elsif ('0' <= $url->[$i] && $url->[$i] <= '9') {
+        $port = $port * 10 + ($url->[$i] - '0');
+      } else {
+        croak "Cannot parse port: port contains non-digit character";
+      }
+    }
+    $self->{port} = $port;
+    return $length;
+  }
+
+  private sub parse_path : int ($self : self, $url : string, $start : int) {
+    my $length = length $url;
+    unless ($start < $length && $url->[$start] == '/') {
+      return $start;
+    }
+    for (my $i = $start; $i < $length; ++$i) {
+      if ($url->[$i] == '?' ||
+          $url->[$i] == '#') {
+        $self->{path} = sliceb((byte [])$url, $start, $i - $start);
+        return $i;
+      }
+    }
+    $self->{path} = sliceb((byte [])$url, $start, $length - $start);
+    return $length;
+  }
+
+  private sub parse_params : int ($self : self, $url : string, $start : int) {
+    my $length = length $url;
+    unless ($start < $length && $url->[$start] == '?') {
+      return $start;
+    }
+    for (my $i = $start + 1; $i < $length; ++$i) {
+      if ($url->[$i] == '#') {
+        $self->{params} = SPVM::HTTP::URL::Parameters->parse(
+          sliceb((byte [])$url, $start + 1, $i - $start - 1)
+        );
+        return $i;
+      }
+    }
+    $self->{params} = SPVM::HTTP::URL::Parameters->parse(
+      sliceb((byte [])$url, $start + 1, $length - $start - 1)
+    );
+    return $length;
+  }
+
+  private sub parse_fragment : void ($self : self, $url : string, $start : int) {
+    my $length = length $url;
+    unless ($url->[$start] == '#') {
+      return;
+    }
+    $self->{fragment} = SPVM::HTTP::URL::Escape->unescape(
+        sliceb((byte [])$url, $start + 1, $length - $start - 1));
+  }
+
+  private sub parse_url : void ($self : self, $url : string) {
+    my $length = length $url;
+    my $next = $self->parse_scheme($url);
+    $next = $self->parse_host($url, $next);
+    if ($next == $length) {
+      return;
+    }
+    $next = $self->parse_path($url, $next);
+    if ($next == $length) {
+      return;
+    }
+    $next = $self->parse_params($url, $next);
+    if ($next == $length) {
+      return;
+    }
+    $self->parse_fragment($url, $next);
+  }
+
+  sub new : SPVM::HTTP::URL () {
+    my $self = new SPVM::HTTP::URL;
+    $self->{scheme} = "";
+    $self->{host} = "";
+    $self->{port} = 0;
+    $self->{path} = "";
+    $self->{params} = SPVM::HTTP::URL::Parameters->new();
+    $self->{fragment} = "";
+    return $self;
+  }
+
+  sub parse : SPVM::HTTP::URL ($url : string) {
+    my $self = SPVM::HTTP::URL->new;
+    $self->parse_url($url);
+    return $self;
+  }
+
+  sub to_str : string ($self : self) {
+    my $url = copy_str($self->{scheme}) . ":";
+    $url .= "//" . $self->{host}; # TODO: escape by punycode if needed
+    if ($self->{port}) { # "host:0" cannot be used
+      $url .= ":" . $self->{port};
+    }
+    $url .= $self->{path};
+    if (@{$self->{params}->keys}) {
+      $url .= "?" . $self->{params}->escape();
+    }
+    if (length($self->{fragment})) {
+      $url .= "#" . SPVM::HTTP::URL::Escape->escape($self->{fragment});
+    }
+    return $url;
+  }
+}
+
+=pod
+
+=head1 NAME
+
+SPVM::HTTP::URL - Uniform Resource Locators
+
+=head1 SYNOPSIS
+
+my $url = SPVM::HTTP::URL->parse($url_escaped);
+my $scheme = $url->{scheme};
+my $host = $url->{host};
+my $port : int = $url->{port};
+my $path = $url->{path};
+eval {
+  my $query_p = $url->{params}->get("p");
+};
+my $fragment = $url->{fragment};
+
+=cut

--- a/lib/SPVM/HTTP/URL.spvm
+++ b/lib/SPVM/HTTP/URL.spvm
@@ -72,15 +72,19 @@ package SPVM::HTTP::URL {
     for (my $i = $start; $i < $length; ++$i) {
       if ($url->[$i] == '/') {
         $self->{path} .= SPVM::HTTP::URL::Escape->unescape(
-            sliceb((byte [])$url, $start, $i - $start)) . "/";
+          sliceb((byte [])$url, $start, $i - $start)) . "/";
         $start = $i + 1;
       }
       elsif ($url->[$i] == '?' ||
           $url->[$i] == '#') {
         $self->{path} .= SPVM::HTTP::URL::Escape->unescape(
-            sliceb((byte [])$url, $start, $i - $start));
+          sliceb((byte [])$url, $start, $i - $start));
         return $i;
       }
+    }
+    if ($start < $length) {
+      $self->{path} .= SPVM::HTTP::URL::Escape->unescape(
+        sliceb((byte [])$url, $start, $length - $start));
     }
     return $length;
   }
@@ -147,6 +151,24 @@ package SPVM::HTTP::URL {
     my $self = SPVM::HTTP::URL->new;
     $self->parse_url($url);
     return $self;
+  }
+
+  sub has_trailing_slash : int ($self : self) {
+    my $length = length($self->{path});
+    return $length && $self->{path}->[$length - 1] == '/';
+  }
+
+  sub enable_trailing_slash : void ($self : self) {
+    if (!$self->has_trailing_slash) {
+      $self->{path} .= "/";
+    }
+  }
+
+  sub disable_trailing_slash : void ($self : self) {
+    if ($self->has_trailing_slash) {
+      $self->{path} = (string)sliceb(
+        (byte[])$self->{path}, 0, length($self->{path}) - 1);
+    }
   }
 
   sub to_str : string ($self : self) {

--- a/lib/SPVM/HTTP/URL/Encode.spvm
+++ b/lib/SPVM/HTTP/URL/Encode.spvm
@@ -1,0 +1,42 @@
+package SPVM::HTTP::URL::Encode {
+  use SPVM::HTTP::URL::Escape;
+
+  sub encode : string ($str : string) {
+    my $escaped = SPVM::HTTP::URL::Escape->escape($str);
+    my $result = "";
+    my $length = length($escaped);
+    for (my $i = 0; $i < $length; ++$i) {
+      if ($i + 2 < $length &&
+          $escaped->[$i] == '%' &&
+          $escaped->[$i + 1] == '2' &&
+          $escaped->[$i + 2] == '0') {
+        $result .= "+";
+        $i += 2;
+      } else {
+        $result .= [$escaped->[$i]];
+      }
+    }
+    return $result;
+  }
+
+  sub decode : string ($str : string) {
+    my $escaped = "";
+    my $length = length($str);
+    for (my $i = 0; $i < $length; ++$i) {
+      if ($str->[$i] == '+') {
+        $escaped .= "%20";
+      } else {
+        $escaped .= [$str->[$i]];
+      }
+    }
+    return SPVM::HTTP::URL::Escape->unescape($escaped);
+  }
+}
+
+=pod
+
+=head1 NAME
+
+SPVM::HTTP::URL::Encode - Encoding and decoding of application/x-www-form-urlencoded encoding
+
+=cut

--- a/lib/SPVM/HTTP/URL/Escape.spvm
+++ b/lib/SPVM/HTTP/URL/Escape.spvm
@@ -16,6 +16,13 @@ package SPVM::HTTP::URL::Escape {
       $c == '~';
   }
 
+  private sub is_sub_delim : int ($c : byte) {
+    return $c == '!' || $c == '$' || $c == '&' ||
+      $c == '\'' || $c == '(' || $c == ')' ||
+      $c == '*' || $c == '+' || $c == ',' ||
+      $c == ';' || $c == '=';
+  }
+
   private sub hex_index : int ($c : byte) {
     if ('0' <= $c && $c <= '9') {
       return $c - '0';
@@ -33,7 +40,7 @@ package SPVM::HTTP::URL::Escape {
     my $length = length $str;
     for (my $i = 0; $i < $length; ++$i) {
       my $c : int = $str->[$i] & 0xFF;
-      if (is_unreserved((byte)$c)) {
+      if (is_unreserved((byte)$c) || is_sub_delim((byte)$c)) {
         $res .= [(byte)$c];
       } else {
         $res .= ['%', $HEX_CHARS->[(int)($c / 16)], $HEX_CHARS->[$c % 16]];
@@ -46,7 +53,7 @@ package SPVM::HTTP::URL::Escape {
     my $res = "";
     my $length = length $str;
     for (my $i = 0; $i < $length; ++$i) {
-      if (is_unreserved($str->[$i])) {
+      if (is_unreserved($str->[$i]) || is_sub_delim($str->[$i])) {
         $res .= [$str->[$i]];
       }
       else {

--- a/lib/SPVM/HTTP/URL/Escape.spvm
+++ b/lib/SPVM/HTTP/URL/Escape.spvm
@@ -1,0 +1,73 @@
+package SPVM::HTTP::URL::Escape {
+  our $HEX_CHARS : ro string;
+
+  BEGIN {
+    $HEX_CHARS = "0123456789ABCDEF";
+  }
+
+  private sub is_unreserved : int ($c : byte) {
+    # RFC3986
+    return ('A' <= $c && $c <= 'Z') ||
+      ('a' <= $c && $c <= 'z') ||
+      ('0' <= $c && $c <= '9') ||
+      $c == '-' ||
+      $c == '.' ||
+      $c == '_' ||
+      $c == '~';
+  }
+
+  private sub hex_index : int ($c : byte) {
+    if ('0' <= $c && $c <= '9') {
+      return $c - '0';
+    }
+    elsif ('A' <= $c && $c <= 'F') {
+      return $c - 'A' + 10;
+    }
+    else {
+      croak "string is broken. invalid hex-digit. c = '" . [$c] . "'";
+    }
+  }
+
+  sub escape : string ($str : string) {
+    my $res = "";
+    my $length = length $str;
+    for (my $i = 0; $i < $length; ++$i) {
+      my $c : int = $str->[$i] & 0xFF;
+      if (is_unreserved((byte)$c)) {
+        $res .= [(byte)$c];
+      } else {
+        $res .= ['%', $HEX_CHARS->[(int)($c / 16)], $HEX_CHARS->[$c % 16]];
+      }
+    }
+    return $res;
+  }
+
+  sub unescape : string ($str : string) {
+    my $res = "";
+    my $length = length $str;
+    for (my $i = 0; $i < $length; ++$i) {
+      if (is_unreserved($str->[$i])) {
+        $res .= [$str->[$i]];
+      }
+      else {
+        unless ($str->[$i] == '%') {
+          croak "string is broken. '%' is expected. str: $str";
+        }
+        unless ($i + 2 < $length) {
+          croak "string is broken. two hex-digits are required after '%'. str: $str";
+        }
+        $res .= [(byte)(hex_index($str->[$i + 1]) * 16 + hex_index($str->[$i + 2]))];
+        $i += 2;
+      }
+    }
+    return $res;
+  }
+}
+
+=pod
+
+=head1 NAME
+
+SPVM::HTTP::URL::Escape - Percent-encode and percent-decode unsafe characters
+
+=cut

--- a/lib/SPVM/HTTP/URL/Escape.spvm
+++ b/lib/SPVM/HTTP/URL/Escape.spvm
@@ -1,8 +1,7 @@
 package SPVM::HTTP::URL::Escape {
-  our $HEX_CHARS : ro string;
 
-  BEGIN {
-    $HEX_CHARS = "0123456789ABCDEF";
+  private sub HEX_CHARS : string () {
+    return "0123456789ABCDEF";
   }
 
   private sub is_unreserved : int ($c : byte) {
@@ -43,7 +42,7 @@ package SPVM::HTTP::URL::Escape {
       if (is_unreserved((byte)$c) || is_sub_delim((byte)$c)) {
         $res .= [(byte)$c];
       } else {
-        $res .= ['%', $HEX_CHARS->[(int)($c / 16)], $HEX_CHARS->[$c % 16]];
+        $res .= ['%', HEX_CHARS()->[(int)($c / 16)], HEX_CHARS()->[$c % 16]];
       }
     }
     return $res;

--- a/lib/SPVM/HTTP/URL/Parameters.spvm
+++ b/lib/SPVM/HTTP/URL/Parameters.spvm
@@ -1,0 +1,80 @@
+package SPVM::HTTP::URL::Parameters {
+  use SPVM::Hash;
+  use SPVM::HTTP::URL::Escape;
+
+  has params : SPVM::Hash;
+
+  sub new : SPVM::HTTP::URL::Parameters () {
+    my $self = new SPVM::HTTP::URL::Parameters;
+    $self->{params} = SPVM::Hash->new;
+    return $self;
+  }
+
+  sub add : void ($self : self, $key : string, $value : string) {
+    unless ($self->{params}->exists($key)) {
+      $self->{params}->set($key, $value);
+    }
+  }
+
+  sub get : string ($self : self, $key : string) {
+    if ($self->{params}->exists($key)) {
+      return (string)($self->{params}->get($key));
+    } else {
+      return undef;
+    }
+  }
+
+  sub keys : string[] ($self : self) {
+    return $self->{params}->keys;
+  }
+
+  sub parse : SPVM::HTTP::URL::Parameters ($str : string) {
+    my $self = SPVM::HTTP::URL::Parameters->new;
+    my $length = length($str);
+    my $start_token = 0;
+    for (my $i = 0; $i < $length; ++$i) {
+      if ($str->[$i] == '=') {
+        my $start_val = $i + 1;
+        my $end_val = -1;
+        for (my $j = $start_val; $j < $length; ++$j) {
+          if ($str->[$j] == '&') {
+            $end_val = $j;
+            last;
+          }
+        }
+        if ($end_val < 0) {
+          $end_val = $length;
+        }
+        my $key = sliceb((byte [])$str, $start_token, $i - $start_token);
+        my $val = SPVM::HTTP::URL::Escape->unescape(
+            sliceb((byte [])$str, $start_val, $end_val - $start_val));
+        $self->add($key, $val);
+        $start_token = $end_val + 1; # if $end_val < $length
+        $i = $end_val;
+      }
+    }
+    return $self;
+  }
+
+  sub escape : string ($self : self) {
+    my $keys = $self->{params}->keys();
+    unless (@$keys) {
+      return "";
+    }
+    sorto($keys, sub : int ($self : self, $left : object, $right : object) {
+      if ((string)$left gt (string)$right) {
+        return 1;
+      }
+      return 0;
+    });
+    my $result = "";
+    for (my $i = 0; $i < @$keys; ++$i) {
+      if ($i > 0) {
+        $result .= "&";
+      }
+      $result .= $keys->[$i] . "=" .
+        SPVM::HTTP::URL::Escape->escape($self->get($keys->[$i]));
+    }
+    return $result;
+  }
+}

--- a/lib/SPVM/HTTP/URL/Parameters.spvm
+++ b/lib/SPVM/HTTP/URL/Parameters.spvm
@@ -1,31 +1,66 @@
 package SPVM::HTTP::URL::Parameters {
-  use SPVM::Hash;
   use SPVM::HTTP::URL::Escape;
 
-  has params : SPVM::Hash;
+  has params : string[][];
+  has size : int;
 
   sub new : SPVM::HTTP::URL::Parameters () {
     my $self = new SPVM::HTTP::URL::Parameters;
-    $self->{params} = SPVM::Hash->new;
+    $self->{params} = new string[][16];
     return $self;
   }
 
   sub add : void ($self : self, $key : string, $value : string) {
-    unless ($self->{params}->exists($key)) {
-      $self->{params}->set($key, $value);
+    unless ($self->{size} < @{$self->{params}}) {
+      my $copied = new string[][$self->{size} * 2];
+      for (my $i = 0; $i < $self->{size}; ++$i) {
+        $copied->[$i] = $self->{params}->[$i];
+      }
+      $self->{size} *= 2;
     }
+    for (my $param_index = 0; $param_index < $self->{size}; ++$param_index) {
+      my $base = $self->{params}->[$param_index];
+      if ($key eq $base->[0]) {
+        my $new_array = new string[@$base + 1];
+        for (my $k = 0; $k < @$base; ++$k) {
+          $new_array->[$k] = $base->[$k];
+        }
+        $new_array->[@$base] = $value;
+        $self->{params}->[$param_index] = $new_array;
+        return;
+      }
+    }
+    $self->{params}->[$self->{size}++] = [$key, $value];
   }
 
   sub get : string ($self : self, $key : string) {
-    if ($self->{params}->exists($key)) {
-      return (string)($self->{params}->get($key));
-    } else {
-      return undef;
+    for (my $i = 0; $i < $self->{size}; ++$i) {
+      my $k = $self->{params}->[$i]->[0];
+      my $v = $self->{params}->[$i]->[1];
+      if ($k eq $key) {
+        return $v;
+      }
     }
+    return undef;
+  }
+
+  sub get_multi : string[] ($self : self, $key : string) {
+    for (my $i = 0; $i < $self->{size}; ++$i) {
+      my $k = $self->{params}->[$i]->[0];
+      if ($k eq $key) {
+        return (string[])sliceo($self->{params}->[$i],
+          1, @{$self->{params}->[$i]} - 1);
+      }
+    }
+    return new string[0];
   }
 
   sub keys : string[] ($self : self) {
-    return $self->{params}->keys;
+    my $keys = new string[$self->{size}];
+    for (my $i = 0; $i < $self->{size}; ++$i) {
+      $keys->[$i] = $self->{params}->[$i]->[0];
+    }
+    return $keys;
   }
 
   sub parse : SPVM::HTTP::URL::Parameters ($str : string) {
@@ -57,7 +92,7 @@ package SPVM::HTTP::URL::Parameters {
   }
 
   sub to_str : string ($self : self) {
-    my $keys = $self->{params}->keys();
+    my $keys = $self->keys();
     unless (@$keys) {
       return "";
     }
@@ -68,12 +103,15 @@ package SPVM::HTTP::URL::Parameters {
       return 0;
     });
     my $result = "";
-    for (my $i = 0; $i < @$keys; ++$i) {
-      if ($i > 0) {
-        $result .= "&";
+    for (my $key_index = 0; $key_index < @$keys; ++$key_index) {
+      my $multi_vals = $self->get_multi($keys->[$key_index]);
+      for (my $val_index = 0; $val_index < @$multi_vals; ++$val_index) {
+        if (length($result)) {
+          $result .= "&";
+        }
+        $result .= $keys->[$key_index] . "=" .
+          SPVM::HTTP::URL::Escape->escape($multi_vals->[$val_index]);
       }
-      $result .= $keys->[$i] . "=" .
-        SPVM::HTTP::URL::Escape->escape($self->get($keys->[$i]));
     }
     return $result;
   }

--- a/lib/SPVM/HTTP/URL/Parameters.spvm
+++ b/lib/SPVM/HTTP/URL/Parameters.spvm
@@ -96,12 +96,6 @@ package SPVM::HTTP::URL::Parameters {
     unless (@$keys) {
       return "";
     }
-    sorto($keys, sub : int ($self : self, $left : object, $right : object) {
-      if ((string)$left gt (string)$right) {
-        return 1;
-      }
-      return 0;
-    });
     my $result = "";
     for (my $key_index = 0; $key_index < @$keys; ++$key_index) {
       my $multi_vals = $self->get_multi($keys->[$key_index]);

--- a/lib/SPVM/HTTP/URL/Parameters.spvm
+++ b/lib/SPVM/HTTP/URL/Parameters.spvm
@@ -56,7 +56,7 @@ package SPVM::HTTP::URL::Parameters {
     return $self;
   }
 
-  sub escape : string ($self : self) {
+  sub to_str : string ($self : self) {
     my $keys = $self->{params}->keys();
     unless (@$keys) {
       return "";

--- a/t/default/lib-SPVM-HTTP-URL-Encode.t
+++ b/t/default/lib-SPVM-HTTP-URL-Encode.t
@@ -1,0 +1,21 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::HTTP::URL::Encode';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::HTTP::URL::Escape
+{
+  ok(TestCase::Lib::SPVM::HTTP::URL::Encode->test_encode);
+}
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-HTTP-URL-Escape.t
+++ b/t/default/lib-SPVM-HTTP-URL-Escape.t
@@ -1,0 +1,21 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::HTTP::URL::Escape';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::HTTP::URL::Escape
+{
+  ok(TestCase::Lib::SPVM::HTTP::URL::Escape->test_escape);
+}
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-HTTP-URL-Parameters.t
+++ b/t/default/lib-SPVM-HTTP-URL-Parameters.t
@@ -1,0 +1,24 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::HTTP::URL::Parameters';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::HTTP::URL::Parameters
+{
+  ok(TestCase::Lib::SPVM::HTTP::URL::Parameters->test_escape);
+  ok(TestCase::Lib::SPVM::HTTP::URL::Parameters->test_parse);
+  ok(TestCase::Lib::SPVM::HTTP::URL::Parameters->test_add_get);
+  ok(TestCase::Lib::SPVM::HTTP::URL::Parameters->test_keys);
+}
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-HTTP-URL.t
+++ b/t/default/lib-SPVM-HTTP-URL.t
@@ -20,6 +20,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::Lib::SPVM::HTTP::URL->test_parse_host_fragment);
   ok(TestCase::Lib::SPVM::HTTP::URL->test_parse_host_path_fragment);
   ok(TestCase::Lib::SPVM::HTTP::URL->test_not_found_scheme_separator);
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_amazon_path_escaped);
   ok(TestCase::Lib::SPVM::HTTP::URL->test_host_is_not_for_url);
 }
 

--- a/t/default/lib-SPVM-HTTP-URL.t
+++ b/t/default/lib-SPVM-HTTP-URL.t
@@ -1,0 +1,28 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::HTTP::URL';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::HTTP::URL
+{
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_parse_escape_all);
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_parse_host);
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_parse_host_path);
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_parse_host_params);
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_parse_host_fragment);
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_parse_host_path_fragment);
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_not_found_scheme_separator);
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_host_is_not_for_url);
+}
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-HTTP-URL.t
+++ b/t/default/lib-SPVM-HTTP-URL.t
@@ -22,6 +22,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::Lib::SPVM::HTTP::URL->test_not_found_scheme_separator);
   ok(TestCase::Lib::SPVM::HTTP::URL->test_amazon_path_escaped);
   ok(TestCase::Lib::SPVM::HTTP::URL->test_host_is_not_for_url);
+  ok(TestCase::Lib::SPVM::HTTP::URL->test_trailing_slash);
 }
 
 # All object is freed

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
@@ -123,6 +123,51 @@ package TestCase::Lib::SPVM::HTTP::URL {
     return 1;
   }
 
+  sub test_amazon_path_escaped : int () {
+    my $url = SPVM::HTTP::URL->parse("https://www.amazon.co.jp/%E3%82%B3%E3%83%B3%E3%83%91%E3%82%A4%E3%83%A9%E2%80%95%E5%8E%9F%E7%90%86%E3%83%BB%E6%8A%80%E6%B3%95%E3%83%BB%E3%83%84%E3%83%BC%E3%83%AB%E3%80%882%E3%80%89-Information-Computing-V-%E3%82%A8%E3%82%A4%E3%83%9B/dp/4781905862/ref=sr_1_22?ie=UTF8&qid=1552415136&sr=8-22&keywords=%E3%82%B3%E3%83%B3%E3%83%91%E3%82%A4%E3%83%A9#%E5%95%86%E5%93%81%E3%81%AE%E8%AA%AC%E6%98%8E");
+    unless ($url->{scheme} eq "https") {
+      return 0;
+    }
+    unless ($url->{host} eq "www.amazon.co.jp") {
+      return 0;
+    }
+    unless ($url->{path} eq "/コンパイラ―原理・技法・ツール〈2〉-Information-Computing-V-エイホ/dp/4781905862/ref=sr_1_22") {
+      return 0;
+    }
+    my $keys = $url->{params}->keys;
+    unless (@$keys == 4) {
+      return 0;
+    }
+    for (my $i = 0; $i < @$keys; ++$i) {
+      my $key = $keys->[$i];
+      my $val = $url->{params}->get($key);
+      if ($key eq "ie") {
+        unless ($val eq "UTF8") {
+          return 0;
+        }
+      }
+      if ($key eq "keywords") {
+        unless ($val eq "コンパイラ") {
+          return 0;
+        }
+      }
+      if ($key eq "qid") {
+        unless ($val eq "1552415136") {
+          return 0;
+        }
+      }
+      if ($key eq "sr") {
+        unless ($val eq "8-22") {
+          return 0;
+        }
+      }
+    }
+    unless ($url->{fragment} eq "商品の説明") {
+      return 0;
+    }
+    return 1;
+  }
+
   sub test_host_is_not_for_url : int () {
     eval {
       SPVM::HTTP::URL->parse("javascript:alert(\"hello%20world\");");

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
@@ -32,6 +32,9 @@ package TestCase::Lib::SPVM::HTTP::URL {
     unless ($url->{path} eq "/blog/posts") {
       return 0;
     }
+    unless ($url->has_trailing_slash == 0) {
+      return 0;
+    }
     unless ((string)($url->{params}->get("p")) eq $p_raw) {
       return 0;
     }
@@ -61,15 +64,29 @@ package TestCase::Lib::SPVM::HTTP::URL {
   }
 
   sub test_parse_host_path : int () {
-    my $url = SPVM::HTTP::URL->parse("https://host/path/hoge/fuga//");
-    unless ($url->{scheme} eq "https") {
-      return 0;
+    {
+      my $url = SPVM::HTTP::URL->parse("https://host/path");
+      unless ($url->{scheme} eq "https") {
+        return 0;
+      }
+      unless ($url->{host} eq "host") {
+        return 0;
+      }
+      unless ($url->{path} eq "/path") {
+        return 0;
+      }
     }
-    unless ($url->{host} eq "host") {
-      return 0;
-    }
-    unless ($url->{path} eq "/path/hoge/fuga//") {
-      return 0;
+    {
+      my $url = SPVM::HTTP::URL->parse("https://host/path/hoge/fuga//");
+      unless ($url->{scheme} eq "https") {
+        return 0;
+      }
+      unless ($url->{host} eq "host") {
+        return 0;
+      }
+      unless ($url->{path} eq "/path/hoge/fuga//") {
+        return 0;
+      }
     }
     return 1;
   }
@@ -183,6 +200,62 @@ package TestCase::Lib::SPVM::HTTP::URL {
       return 0;
     }
     $@ = undef;
+    return 1;
+  }
+
+  sub test_trailing_slash : int () {
+    my $tests = [
+      [
+        ["http://www.example.com", "http://www.example.com/"],
+        ["", "/"],
+      ],
+      [
+        ["http://www.google.com?q=spvm", "http://www.google.com/?q=spvm"],
+        ["", "/"],
+      ],
+      [
+        ["http://www.blog.com/posts", "http://www.blog.com/posts/"],
+        ["/posts", "/posts/"],
+      ],
+      [
+        ["http://www.blog.com/posts?p=spvm", "http://www.blog.com/posts/?p=spvm"],
+        ["/posts", "/posts/"],
+      ]
+    ];
+    for (my $i = 0; $i < @$tests; ++$i) {
+      my $test_url = $tests->[$i]->[0];
+      my $test_path = $tests->[$i]->[1];
+      my $url = SPVM::HTTP::URL->parse($test_url->[0]);
+      unless ($url->has_trailing_slash == 0 &&
+          $url->{path} eq $test_path->[0] &&
+          $url->to_str eq $test_url->[0]) {
+        return 0;
+      }
+      $url->enable_trailing_slash;
+      unless ($url->has_trailing_slash == 1 &&
+          $url->{path} eq $test_path->[1] &&
+          $url->to_str eq $test_url->[1]) {
+        return 0;
+      }
+      $url->enable_trailing_slash;
+      unless ($url->has_trailing_slash == 1 &&
+          $url->{path} eq $test_path->[1] &&
+          $url->to_str eq $test_url->[1]) {
+        return 0;
+      }
+      $url->disable_trailing_slash;
+      unless ($url->has_trailing_slash == 0 &&
+          $url->{path} eq $test_path->[0] &&
+          $url->to_str eq $test_url->[0]) {
+        return 0;
+      }
+      $url->disable_trailing_slash;
+      unless ($url->has_trailing_slash == 0 &&
+          $url->{path} eq $test_path->[0] &&
+          $url->to_str eq $test_url->[0]) {
+        return 0;
+      }
+    }
     return 1;
   }
 }

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
@@ -1,0 +1,136 @@
+package TestCase::Lib::SPVM::HTTP::URL {
+  use SPVM::HTTP::URL;
+
+  sub test_parse_escape_all : int () {
+    my $p_raw = "abc";
+    my $p_escaped = "abc";
+    my $q_raw = "尾骶骨𠮷 🤔";
+    my $q_escaped = "%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%20%F0%9F%A4%94";
+    my $fragment_raw = "🤔 𠮷尾骶骨";
+    my $fragment_escaped = "%F0%9F%A4%94%20%F0%A0%AE%B7%E5%B0%BE%E9%AA%B6%E9%AA%A8";
+    my $url = SPVM::HTTP::URL->parse(
+      "http://www.example.com:8888/blog/posts?q=$q_escaped&p=$p_escaped&p=dummy#$fragment_escaped");
+    {
+      my $got = $url->to_str();
+      my $expected = "http://www.example.com:8888/blog/posts?p=$p_escaped&q=$q_escaped#$fragment_escaped";
+      unless ($url->to_str() eq $expected) {
+        warn("     got: '$got'\nexpected: '$expected'");
+        return 0;
+      }
+    }
+    unless ($url->{scheme} eq "http") {
+      return 0;
+    }
+    unless ($url->{host} eq "www.example.com") {
+      return 0;
+    }
+    unless ($url->{port} == 8888) {
+      return 0;
+    }
+    unless ($url->{path} eq "/blog/posts") {
+      return 0;
+    }
+    unless ((string)($url->{params}->get("p")) eq $p_raw) {
+      return 0;
+    }
+    unless ((string)($url->{params}->get("q")) eq $q_raw) {
+      return 0;
+    }
+    unless ((string)($url->{fragment} eq $fragment_raw)) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_parse_host : int () {
+    my $url = SPVM::HTTP::URL->parse("https://host");
+    unless ($url->{scheme} eq "https") {
+      return 0;
+    }
+    unless ($url->{host} eq "host") {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_parse_host_path : int () {
+    my $url = SPVM::HTTP::URL->parse("https://host/path/hoge/fuga//");
+    unless ($url->{scheme} eq "https") {
+      return 0;
+    }
+    unless ($url->{host} eq "host") {
+      return 0;
+    }
+    unless ($url->{path} eq "/path/hoge/fuga//") {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_parse_host_params : int () {
+    my $url = SPVM::HTTP::URL->parse("https://host?abc=%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%20%F0%9F%A4%94");
+    unless ($url->{scheme} eq "https") {
+      return 0;
+    }
+    unless ($url->{host} eq "host") {
+      return 0;
+    }
+    unless ($url->{params}->get("abc") eq "尾骶骨𠮷 🤔") {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_parse_host_fragment : int () {
+    my $url = SPVM::HTTP::URL->parse("https://host#%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%20%F0%9F%A4%94");
+    unless ($url->{scheme} eq "https") {
+      return 0;
+    }
+    unless ($url->{host} eq "host") {
+      return 0;
+    }
+    unless ($url->{fragment} eq "尾骶骨𠮷 🤔") {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_parse_host_path_fragment : int () {
+    my $url = SPVM::HTTP::URL->parse("https://host/blog/posts#%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%20%F0%9F%A4%94");
+    unless ($url->{scheme} eq "https") {
+      return 0;
+    }
+    unless ($url->{host} eq "host") {
+      return 0;
+    }
+    unless ($url->{path} eq "/blog/posts") {
+      return 0;
+    }
+    unless ($url->{fragment} eq "尾骶骨𠮷 🤔") {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_not_found_scheme_separator : int () {
+    eval {
+      SPVM::HTTP::URL->parse("http//www.example.com");
+    };
+    unless ($@) {
+      return 0;
+    }
+    $@ = undef;
+    return 1;
+  }
+
+  sub test_host_is_not_for_url : int () {
+    eval {
+      SPVM::HTTP::URL->parse("javascript:alert(\"hello%20world\");");
+    };
+    unless ($@) {
+      return 0;
+    }
+    $@ = undef;
+    return 1;
+  }
+}

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
@@ -4,15 +4,17 @@ package TestCase::Lib::SPVM::HTTP::URL {
   sub test_parse_escape_all : int () {
     my $p_raw = "abc";
     my $p_escaped = "abc";
+    my $p_raw_2 = "d";
+    my $p_escaped_2 = "d";
     my $q_raw = "尾骶骨𠮷 🤔";
     my $q_escaped = "%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%20%F0%9F%A4%94";
     my $fragment_raw = "🤔 𠮷尾骶骨";
     my $fragment_escaped = "%F0%9F%A4%94%20%F0%A0%AE%B7%E5%B0%BE%E9%AA%B6%E9%AA%A8";
     my $url = SPVM::HTTP::URL->parse(
-      "http://www.example.com:8888/blog/posts?q=$q_escaped&p=$p_escaped&p=dummy#$fragment_escaped");
+      "http://www.example.com:8888/blog/posts?q=$q_escaped&p=$p_escaped&p=$p_escaped_2#$fragment_escaped");
     {
       my $got = $url->to_str();
-      my $expected = "http://www.example.com:8888/blog/posts?p=$p_escaped&q=$q_escaped#$fragment_escaped";
+      my $expected = "http://www.example.com:8888/blog/posts?p=$p_escaped&p=$p_escaped_2&q=$q_escaped#$fragment_escaped";
       unless ($url->to_str() eq $expected) {
         warn("     got: '$got'\nexpected: '$expected'");
         return 0;
@@ -31,6 +33,11 @@ package TestCase::Lib::SPVM::HTTP::URL {
       return 0;
     }
     unless ((string)($url->{params}->get("p")) eq $p_raw) {
+      return 0;
+    }
+    my $multi_p = $url->{params}->get_multi("p");
+    unless (@$multi_p == 2 &&
+        $multi_p->[0] eq $p_raw && $multi_p->[1] eq $p_raw_2) {
       return 0;
     }
     unless ((string)($url->{params}->get("q")) eq $q_raw) {

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL.spvm
@@ -14,7 +14,7 @@ package TestCase::Lib::SPVM::HTTP::URL {
       "http://www.example.com:8888/blog/posts?q=$q_escaped&p=$p_escaped&p=$p_escaped_2#$fragment_escaped");
     {
       my $got = $url->to_str();
-      my $expected = "http://www.example.com:8888/blog/posts?p=$p_escaped&p=$p_escaped_2&q=$q_escaped#$fragment_escaped";
+      my $expected = "http://www.example.com:8888/blog/posts?q=$q_escaped&p=$p_escaped&p=$p_escaped_2#$fragment_escaped";
       unless ($url->to_str() eq $expected) {
         warn("     got: '$got'\nexpected: '$expected'");
         return 0;

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Encode.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Encode.spvm
@@ -1,0 +1,21 @@
+package TestCase::Lib::SPVM::HTTP::URL::Encode {
+  use SPVM::HTTP::URL::Encode;
+
+  sub test_encode : int () {
+    my $raw_string = "尾骶骨𠮷 🤔";
+    my $expected_encoded = "%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7+%F0%9F%A4%94";
+    my $got_encoded = SPVM::HTTP::URL::Encode->encode($raw_string);
+    unless ($got_encoded eq $expected_encoded) {
+      warn("     got_encoded: $got_encoded");
+      warn("expected_encoded: $expected_encoded");
+      return 0;
+    }
+    my $got_decoded = SPVM::HTTP::URL::Encode->decode($got_encoded);
+    unless ($got_decoded eq $raw_string) {
+      warn("got_decoded: $got_decoded");
+      warn(" raw_string: $raw_string");
+      return 0;
+    }
+    return 1;
+  }
+}

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Escape.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Escape.spvm
@@ -1,0 +1,21 @@
+package TestCase::Lib::SPVM::HTTP::URL::Escape {
+  use SPVM::HTTP::URL::Escape;
+
+  sub test_escape : int () {
+    my $raw_string = "尾骶骨𠮷 🤔";
+    my $expected_escaped = "%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%20%F0%9F%A4%94";
+    my $got_escaped = SPVM::HTTP::URL::Escape->escape($raw_string);
+    unless ($got_escaped eq $expected_escaped) {
+      warn("got_escaped: $got_escaped");
+      warn("expected_escaped: $expected_escaped");
+      return 0;
+    }
+    my $got_unescaped = SPVM::HTTP::URL::Escape->unescape($got_escaped);
+    unless ($got_unescaped eq $raw_string) {
+      warn("got_unescaped: $got_unescaped");
+      warn("raw_string: $raw_string");
+      return 0;
+    }
+    return 1;
+  }
+}

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Parameters.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Parameters.spvm
@@ -6,11 +6,11 @@ package TestCase::Lib::SPVM::HTTP::URL::Parameters {
     $params->add("foo" => "尾骶骨𠮷🤔");
     $params->add("hoge" => "fuga");
     $params->add("foo" => "piyo");
-    my $got = $params->escape();
-    my $expected = "foo=%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%F0%9F%A4%94&hoge=fuga";
+    my $got = $params->to_str();
+    my $expected = "foo=%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%F0%9F%A4%94&foo=piyo&hoge=fuga";
     unless ($got eq $expected) {
       # parameter keys should be sorted and duplicate params are not accepted.
-      warn("failed to escape parameters. got: '$got' expected: '$expected'");
+      warn("failed to escape parameters.\n     got: '$got'\nexpected: '$expected'");
       return 0;
     }
     return 1;
@@ -30,17 +30,22 @@ package TestCase::Lib::SPVM::HTTP::URL::Parameters {
 
   sub test_add_get : int () {
     my $params = SPVM::HTTP::URL::Parameters->new;
-    $params->add("hoge", "fuga");
-    unless ($params->get("hoge") eq "fuga") {
+    $params->add("array", "first_value");
+    $params->add("array", "second_value");
+    unless ($params->get("array") eq "first_value") {
       return 0;
     }
-    $params->add("hoge", "abc");
-    unless ($params->get("hoge") eq "fuga") {
-      warn("first value is read if duplicate keys are given");
+    my $multi_val = $params->get_multi("array");
+    unless (@$multi_val == 2 &&
+      $multi_val->[0] eq "first_value" && $multi_val->[1] eq "second_value") {
       return 0;
     }
     $params->add("fuga", "xyz");
     unless ($params->get("fuga") eq "xyz") {
+      return 0;
+    }
+    $multi_val = $params->get_multi("fuga");
+    unless (@$multi_val == 1 && $multi_val->[0] eq "xyz") {
       return 0;
     }
     unless ($params->get("unknown") == undef) {

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Parameters.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Parameters.spvm
@@ -1,0 +1,75 @@
+package TestCase::Lib::SPVM::HTTP::URL::Parameters {
+  use SPVM::HTTP::URL::Parameters;
+
+  sub test_escape : int () {
+    my $params = SPVM::HTTP::URL::Parameters->new;
+    $params->add("foo" => "尾骶骨𠮷🤔");
+    $params->add("hoge" => "fuga");
+    $params->add("foo" => "piyo");
+    my $got = $params->escape();
+    my $expected = "foo=%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%F0%9F%A4%94&hoge=fuga";
+    unless ($got eq $expected) {
+      # parameter keys should be sorted and duplicate params are not accepted.
+      warn("failed to escape parameters. got: '$got' expected: '$expected'");
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_parse : int () {
+    my $params = SPVM::HTTP::URL::Parameters->parse(
+        "foo=%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%F0%9F%A4%94&hoge=fuga&foo=piyo");
+    unless ($params->get("foo") eq "尾骶骨𠮷🤔") {
+      return 0;
+    }
+    unless ($params->get("hoge") eq "fuga") {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_add_get : int () {
+    my $params = SPVM::HTTP::URL::Parameters->new;
+    $params->add("hoge", "fuga");
+    unless ($params->get("hoge") eq "fuga") {
+      return 0;
+    }
+    $params->add("hoge", "abc");
+    unless ($params->get("hoge") eq "fuga") {
+      warn("first value is read if duplicate keys are given");
+      return 0;
+    }
+    $params->add("fuga", "xyz");
+    unless ($params->get("fuga") eq "xyz") {
+      return 0;
+    }
+    unless ($params->get("unknown") == undef) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_keys : int () {
+    my $params = SPVM::HTTP::URL::Parameters->new;
+    unless (@{$params->keys} == 0) {
+      return 0;
+    }
+    $params->add("k", "v1");
+    unless (equals_strarray($params->keys, ["k"])) {
+      return 0;
+    }
+    $params->add("k", "v2");
+    unless (equals_strarray($params->keys, ["k"])) {
+      return 0;
+    }
+    $params->add("k2", "v3");
+    {
+      my $keys = $params->keys;
+      unless (equals_strarray($keys, ["k", "k2"]) ||
+          equals_strarray($keys, ["k2", "k"])) {
+        return 0;
+      }
+    }
+    return 1;
+  }
+}


### PR DESCRIPTION
- URL 文字列をパース / 構築するモジュール

**UPDATE: 2019/03/16**
```perl
package SPVM::HTTP::URL {
  # [scheme:][//[host][/path][?query][#fragment]
  has scheme    : public string;
  has host      : public string;
  has port      : public int;
  has path      : public string;
  has params    : public SPVM::HTTP::URL::Parameters;
  has fragment  : public string;

  sub parse : SPVM::HTTP::URL ($url : string); # constructor
  sub has_trailing_slash : int ($self : self); # pathの末尾で判定
  sub enable_trailing_slash : void ($self : self); # pathの末尾に/がなければ追加
  sub disable_trailing_slash : void ($self : self); # pathの末尾に/があれば削除
  sub to_str : string ($self : self);
}
```

- URLエスケープ (パーセントエンコーディング)
```perl
package SPVM::HTTP::URL::Escape {
  sub escape : string ($str : string);
  sub unescape : string ($str : string);
}
```

- URLエンコード (`application/x-www-form-urlencoded`)
```perl
package SPVM::HTTP::URL::Encode {
  sub encode : string ($str : string);
  sub decode : string ($str : string);
}
```

- クエリパラメータを解析するモジュール。UTF8で `add` / `get` を行い、escape で `SPVM::HTTP::URL::Escape` にかける
```perl
package SPVM::HTTP::URL::Parameters {
  has params : string[][];
  has size : int;

  sub new : SPVM::HTTP::URL::Parameters ();
  sub add : void ($self : self, $key : string, $value : string); # パラメータを追加
  sub get : string ($self : self, $key : string); # キーに対して値を取得(複数あるときは先頭を取得)
  sub get_multi : string[] ($self : self, $key : string); # キーに対して値を複数(0個以上)取得
  sub keys : string[] ($self : self);
  sub parse : SPVM::HTTP::URL::Parameters ($str : string);
  sub to_str : string ($self : self); # パラメータを URL エスケープして出力
}
```