### PR TITLE
[HTTP Headers] SPVM::Time::*

### DIFF
--- a/lib/SPVM/Time/Format.c
+++ b/lib/SPVM/Time/Format.c
@@ -11,7 +11,7 @@ int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALU
 
   struct tm tm;
   if (!strptime(buf, format, &tm)) {
-    SPVM_CROAK("Can't parse format", "SPVM/Time/Format.c", __LINE__);
+    SPVM_CROAK("Can't parse buffer like format", "SPVM/Time/Format.c", __LINE__);
   }
 
   stack[0].lval = mktime(&tm);
@@ -33,7 +33,7 @@ int32_t SPNATIVE__SPVM__Time__Format__strftime(SPVM_ENV* env, SPVM_VALUE* stack)
 
   if (!strftime(buffer, capacity, format, &dt)) {
     env->dec_ref_count(env, obuffer);
-    SPVM_CROAK("Can't write as format", "SPVM/Time/Format.c", __LINE__);
+    SPVM_CROAK("Can't write like format", "SPVM/Time/Format.c", __LINE__);
   }
 
   int32_t length = sprintf(buffer, "%s", buffer);

--- a/lib/SPVM/Time/Format.c
+++ b/lib/SPVM/Time/Format.c
@@ -1,6 +1,8 @@
 #include "spvm_native.h"
 
+#include <memory.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <time.h>
 
 int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALUE* stack) {
@@ -13,6 +15,34 @@ int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALU
   }
 
   stack[0].lval = mktime(&tm);
+
+  return SPVM_SUCCESS;
+}
+
+int32_t SPNATIVE__SPVM__Time__Format__strftime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  const char* format = (const char*)env->belems(env, stack[0].oval);
+  time_t epoch = stack[1].lval;
+
+  struct tm dt;
+  gmtime_r(&epoch, &dt); // FIXME: only support UTC for now
+
+  int32_t capacity = 100;
+  void* obuffer = env->new_barray_raw(env, capacity);
+  env->inc_ref_count(env, obuffer);
+  char* buffer = (char *)(env->belems(env, obuffer));
+
+  if (!strftime(buffer, capacity, format, &dt)) {
+    env->dec_ref_count(env, obuffer);
+    SPVM_CROAK("Can't write as format", "SPVM/Time/Format.c", __LINE__);
+  }
+
+  int32_t length = sprintf(buffer, "%s", buffer);
+  void* oline = env->new_barray_raw(env, length);
+  int8_t* line = env->belems(env, oline);
+  memcpy(line, buffer, length);
+
+  env->dec_ref_count(env, obuffer);
+  stack[0].oval = oline;
 
   return SPVM_SUCCESS;
 }

--- a/lib/SPVM/Time/Format.c
+++ b/lib/SPVM/Time/Format.c
@@ -7,6 +7,15 @@
 #include <locale.h>
 
 int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  if (!stack[0].oval) {
+    SPVM_CROAK("buffer must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
+  if (!stack[1].oval) {
+    SPVM_CROAK("format must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
+  if (!stack[2].oval) {
+    SPVM_CROAK("locale must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
   const char* buf = (const char*)env->belems(env, stack[0].oval);
   const char* format = (const char*)env->belems(env, stack[1].oval);
   const char* locale = (const char*)env->belems(env, stack[2].oval);
@@ -26,6 +35,12 @@ int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALU
 }
 
 int32_t SPNATIVE__SPVM__Time__Format__strftime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  if (!stack[0].oval) {
+    SPVM_CROAK("format must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
+  if (!stack[2].oval) {
+    SPVM_CROAK("locale must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
   const char* format = (const char*)env->belems(env, stack[0].oval);
   time_t epoch = stack[1].lval;
   const char* locale = (const char*)env->belems(env, stack[2].oval);

--- a/lib/SPVM/Time/Format.c
+++ b/lib/SPVM/Time/Format.c
@@ -1,0 +1,18 @@
+#include "spvm_native.h"
+
+#include <stdlib.h>
+#include <time.h>
+
+int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  const char* buf = (const char*)env->belems(env, stack[0].oval);
+  const char* format = (const char*)env->belems(env, stack[1].oval);
+
+  struct tm tm;
+  if (!strptime(buf, format, &tm)) {
+    SPVM_CROAK("Can't parse format", "SPVM/Time/Format.c", __LINE__);
+  }
+
+  stack[0].lval = mktime(&tm);
+
+  return SPVM_SUCCESS;
+}

--- a/lib/SPVM/Time/Format.spvm
+++ b/lib/SPVM/Time/Format.spvm
@@ -1,23 +1,32 @@
 package SPVM::Time::Format {
   use SPVM::Time::Moment;
 
-  has template : string;
+  has format : ro string;
+  has locale : ro string;
 
-  private native sub epoch_by_strptime : long ($buf : string, $format : string);
-  private native sub strftime : string ($format : string, $epoch : long);
+  private native sub epoch_by_strptime : long ($buf : string, $format : string, $locale : string);
+  private native sub strftime : string ($format : string, $epoch : long, $locale : string);
 
   sub new : SPVM::Time::Format ($format : string) {
     my $self = new SPVM::Time::Format;
-    $self->{template} = $format;
+    $self->{format} = $format;
+    $self->{locale} = "C";
+    return $self;
+  }
+
+  sub RFC1123 : SPVM::Time::Format () {
+    my $self = new SPVM::Time::Format;
+    $self->{format} = "%a, %d %b %Y %H:%M:%S %Z"; # using gmtime_r is expected in strftime.
+    $self->{locale} = "C";
     return $self;
   }
 
   sub parse : SPVM::Time::Moment ($self : self, $string : string) {
-    my $epoch = SPVM::Time::Format->epoch_by_strptime($string, $self->{template});
+    my $epoch = SPVM::Time::Format->epoch_by_strptime($string, $self->{format}, $self->{locale});
     return SPVM::Time::Moment->from_epoch($epoch);
   }
 
   sub time_to_str : string ($self : self, $moment : SPVM::Time::Moment) {
-    return SPVM::Time::Format->strftime($self->{template}, $moment->epoch);
+    return SPVM::Time::Format->strftime($self->{format}, $moment->epoch, $self->{locale});
   }
 }

--- a/lib/SPVM/Time/Format.spvm
+++ b/lib/SPVM/Time/Format.spvm
@@ -4,6 +4,7 @@ package SPVM::Time::Format {
   has template : string;
 
   private native sub epoch_by_strptime : long ($buf : string, $format : string);
+  private native sub strftime : string ($format : string, $epoch : long);
 
   sub new : SPVM::Time::Format ($format : string) {
     my $self = new SPVM::Time::Format;
@@ -14,5 +15,9 @@ package SPVM::Time::Format {
   sub parse : SPVM::Time::Moment ($self : self, $string : string) {
     my $epoch = SPVM::Time::Format->epoch_by_strptime($string, $self->{template});
     return SPVM::Time::Moment->from_epoch($epoch);
+  }
+
+  sub time_to_str : string ($self : self, $moment : SPVM::Time::Moment) {
+    return SPVM::Time::Format->strftime($self->{template}, $moment->epoch);
   }
 }

--- a/lib/SPVM/Time/Format.spvm
+++ b/lib/SPVM/Time/Format.spvm
@@ -1,0 +1,18 @@
+package SPVM::Time::Format {
+  use SPVM::Time::Moment;
+
+  has template : string;
+
+  private native sub epoch_by_strptime : long ($buf : string, $format : string);
+
+  sub new : SPVM::Time::Format ($format : string) {
+    my $self = new SPVM::Time::Format;
+    $self->{template} = $format;
+    return $self;
+  }
+
+  sub parse : SPVM::Time::Moment ($self : self, $string : string) {
+    my $epoch = SPVM::Time::Format->epoch_by_strptime($string, $self->{template});
+    return SPVM::Time::Moment->from_epoch($epoch);
+  }
+}

--- a/lib/SPVM/Time/Moment.c
+++ b/lib/SPVM/Time/Moment.c
@@ -1,0 +1,46 @@
+#include "spvm_native.h"
+
+#include <stdlib.h>
+#include <time.h>
+
+// FIXME: Remove duplication between Moment.c and Format.c
+int32_t SPNATIVE__SPVM__Time__Moment__strptime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  const char* buf = (const char*)env->belems(env, stack[0].oval);
+  const char* format = (const char*)env->belems(env, stack[1].oval);
+
+  struct tm dt;
+  if (!strptime(buf, format, &dt)) {
+    return SPVM_EXCEPTION;
+  }
+
+  stack[0].ival = dt.tm_sec;
+  stack[1].ival = dt.tm_min;
+  stack[2].ival = dt.tm_hour;
+  stack[3].ival = dt.tm_mday;
+  stack[4].ival = dt.tm_mon;
+  stack[5].ival = dt.tm_year;
+  stack[6].ival = dt.tm_wday;
+  stack[7].ival = dt.tm_yday;
+  stack[8].ival = dt.tm_isdst;
+
+  return SPVM_SUCCESS;
+}
+
+int32_t SPNATIVE__SPVM__Time__Moment__gmtime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  time_t epoch = stack[0].lval;
+
+  struct tm dt;
+  gmtime_r(&epoch, &dt);
+
+  stack[0].ival = dt.tm_sec;
+  stack[1].ival = dt.tm_min;
+  stack[2].ival = dt.tm_hour;
+  stack[3].ival = dt.tm_mday;
+  stack[4].ival = dt.tm_mon;
+  stack[5].ival = dt.tm_year;
+  stack[6].ival = dt.tm_wday;
+  stack[7].ival = dt.tm_yday;
+  stack[8].ival = dt.tm_isdst;
+
+  return SPVM_SUCCESS;
+}

--- a/lib/SPVM/Time/Moment.spvm
+++ b/lib/SPVM/Time/Moment.spvm
@@ -1,0 +1,74 @@
+package SPVM::Time::Moment {
+  use SPVM::Time::tm_9i;
+
+  has epoch : ro long;
+
+  enum {
+    MONDAY = 1,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY,
+  }
+
+  private native sub gmtime : SPVM::Time::tm_9i ($epoch : long);
+
+  sub new_with_epoch : SPVM::Time::Moment ($epoch : long) {
+    return SPVM::Time::Moment->from_epoch($epoch);
+  }
+
+  sub from_epoch : SPVM::Time::Moment ($epoch : long) {
+    my $self = new SPVM::Time::Moment;
+    $self->{epoch} = $epoch;
+    return $self;
+  }
+
+  sub now : SPVM::Time::Moment () {
+    return SPVM::Time::Moment->from_epoch(time());
+  }
+
+  # TODO: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_16
+  # sub new_with : SPVM::Time::Moment ($args : SPVM::Hash) {}
+
+  sub new_with_offset_same_instant : SPVM::Time::Moment ($self : SPVM::Time::Moment, $offset_minutes : int) {
+    return SPVM::Time::Moment->from_epoch($self->epoch + $offset_minutes * 60);
+  }
+
+  #sub new_with_offset_same_local : SPVM::Time::Moment ($base : SPVM::Time::Moment) {
+  #  return new SPVM::Time::Moment;
+  #}
+
+  sub year : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_year} + 1900;
+  }
+
+  sub month : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_mon} + 1;
+  }
+
+  sub day : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_mday};
+  }
+
+  sub day_of_week : int ($self : self) { # [1=Monday, 7=Sunday]
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_wday};
+  }
+
+  sub day_of_year : int ($self : self) { # [1, 366]
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_yday} + 1;
+  }
+
+  sub hour : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_hour};
+  }
+
+  sub minute : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_min};
+  }
+
+  sub second : int ($self : self) { # [0, 59]
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_sec};
+  }
+}

--- a/lib/SPVM/Time/Moment.spvm
+++ b/lib/SPVM/Time/Moment.spvm
@@ -32,14 +32,6 @@ package SPVM::Time::Moment {
   # TODO: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_16
   # sub new_with : SPVM::Time::Moment ($args : SPVM::Hash) {}
 
-  sub new_with_offset_same_instant : SPVM::Time::Moment ($self : SPVM::Time::Moment, $offset_minutes : int) {
-    return SPVM::Time::Moment->from_epoch($self->epoch + $offset_minutes * 60);
-  }
-
-  #sub new_with_offset_same_local : SPVM::Time::Moment ($base : SPVM::Time::Moment) {
-  #  return new SPVM::Time::Moment;
-  #}
-
   sub year : int ($self : self) {
     return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_year} + 1900;
   }

--- a/lib/SPVM/Time/tm_9i.spvm
+++ b/lib/SPVM/Time/tm_9i.spvm
@@ -1,0 +1,11 @@
+package SPVM::Time::tm_9i : value_t {
+  has tm_sec : int;
+  has tm_min : int;
+  has tm_hour : int;
+  has tm_mday : int;
+  has tm_mon : int;
+  has tm_year : int;
+  has tm_wday : int;
+  has tm_yday : int;
+  has tm_isdst : int;
+}

--- a/t/default/lib-SPVM-Time-Format.t
+++ b/t/default/lib-SPVM-Time-Format.t
@@ -14,6 +14,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 # SPVM::Time::Format
 {
   ok(TestCase::Lib::SPVM::Time::Format->test_parse());
+  ok(TestCase::Lib::SPVM::Time::Format->test_timezone_JST());
 }
 
 

--- a/t/default/lib-SPVM-Time-Format.t
+++ b/t/default/lib-SPVM-Time-Format.t
@@ -15,6 +15,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 {
   ok(TestCase::Lib::SPVM::Time::Format->test_parse());
   ok(TestCase::Lib::SPVM::Time::Format->test_time_to_str());
+  ok(TestCase::Lib::SPVM::Time::Format->test_RFC1123());
   ok(TestCase::Lib::SPVM::Time::Format->test_timezone_JST());
 }
 

--- a/t/default/lib-SPVM-Time-Format.t
+++ b/t/default/lib-SPVM-Time-Format.t
@@ -14,6 +14,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 # SPVM::Time::Format
 {
   ok(TestCase::Lib::SPVM::Time::Format->test_parse());
+  ok(TestCase::Lib::SPVM::Time::Format->test_time_to_str());
   ok(TestCase::Lib::SPVM::Time::Format->test_timezone_JST());
 }
 

--- a/t/default/lib-SPVM-Time-Format.t
+++ b/t/default/lib-SPVM-Time-Format.t
@@ -1,0 +1,22 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::Time::Format';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::Time::Format
+{
+  ok(TestCase::Lib::SPVM::Time::Format->test_parse());
+}
+
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-Time-Moment.t
+++ b/t/default/lib-SPVM-Time-Moment.t
@@ -1,0 +1,24 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::Time::Moment';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::Time::Moment
+{
+  ok(TestCase::Lib::SPVM::Time::Moment->test_basic());
+  ok(TestCase::Lib::SPVM::Time::Moment->test_leap_year());
+  ok(TestCase::Lib::SPVM::Time::Moment->test_now());
+}
+
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
@@ -1,5 +1,6 @@
 package TestCase::Lib::SPVM::Time::Format {
   use SPVM::Time::Format;
+  use SPVM::Time::Moment;
 
   sub test_parse : int () {
     my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
@@ -32,6 +33,12 @@ package TestCase::Lib::SPVM::Time::Format {
       return 0;
     }
     return 1;
+  }
+
+  sub test_time_to_str : int () {
+    my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
+    my $output = $format->time_to_str(SPVM::Time::Moment->from_epoch(1553518297));
+    return $output eq "2019-03-25 12:51:37 UTC";
   }
 
   sub test_timezone_JST : int () {

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
@@ -1,0 +1,35 @@
+package TestCase::Lib::SPVM::Time::Format {
+  use SPVM::Time::Format;
+  sub test_parse : int () {
+    my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
+    my $m = $format->parse("2019-03-25 12:51:37 GMT");
+    unless ($m->epoch == 1553518297) {
+      return 0;
+    }
+    unless ($m->year == 2019) {
+      return 0;
+    }
+    unless ($m->month == 3) {
+      return 0;
+    }
+    unless ($m->day == 25) {
+      return 0;
+    }
+    unless ($m->day_of_week == SPVM::Time::Moment->MONDAY) {
+      return 0;
+    }
+    unless ($m->day_of_year == 84) {
+      return 0;
+    }
+    unless ($m->hour == 12) {
+      return 0;
+    }
+    unless ($m->minute == 51) {
+      return 0;
+    }
+    unless ($m->second == 37) {
+      return 0;
+    }
+    return 1;
+  }
+}

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
@@ -1,5 +1,6 @@
 package TestCase::Lib::SPVM::Time::Format {
   use SPVM::Time::Format;
+
   sub test_parse : int () {
     my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
     my $m = $format->parse("2019-03-25 12:51:37 GMT");
@@ -31,5 +32,11 @@ package TestCase::Lib::SPVM::Time::Format {
       return 0;
     }
     return 1;
+  }
+
+  sub test_timezone_JST : int () {
+    my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
+    my $m = $format->parse("2019-03-25 12:51:37 JST");
+    return $m->epoch == 1553485897;
   }
 }

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
@@ -35,6 +35,18 @@ package TestCase::Lib::SPVM::Time::Format {
     return 1;
   }
 
+  sub test_RFC1123 : int () {
+    my $format = SPVM::Time::Format->RFC1123;
+    unless ($format->parse("Wed, 02 Jan 2030 03:04:56 GMT")->epoch == 1893553496) { # TODO: Allow UTC
+      return 0;
+    }
+    unless ($format->time_to_str(SPVM::Time::Moment->from_epoch(1893553496)) eq "Wed, 02 Jan 2030 03:04:56 UTC") {
+      warn ($format->time_to_str(SPVM::Time::Moment->from_epoch(1893553496)));
+      return 0;
+    }
+    return 1;
+  }
+
   sub test_time_to_str : int () {
     my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
     my $output = $format->time_to_str(SPVM::Time::Moment->from_epoch(1553518297));

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Moment.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Moment.spvm
@@ -1,0 +1,73 @@
+package TestCase::Lib::SPVM::Time::Moment {
+  use SPVM::Time::Moment;
+
+  sub test_basic : int () {
+    # UTC: 2019/3/25 Monday 12:51:37
+    my $m = SPVM::Time::Moment->from_epoch(1553518297);
+    unless ($m->epoch == 1553518297) {
+      return 0;
+    }
+    unless ($m->year == 2019) {
+      return 0;
+    }
+    unless ($m->month == 3) {
+      return 0;
+    }
+    unless ($m->day == 25) {
+      return 0;
+    }
+    unless ($m->day_of_week == SPVM::Time::Moment->MONDAY && SPVM::Time::Moment->MONDAY == 1) {
+      return 0;
+    }
+    # perl -MDateTime -le 'my $dt = DateTime->from_epoch(epoch => 1553518297); print $dt->day_of_year'
+    unless ($m->day_of_year == 84) {
+      return 0;
+    }
+    unless ($m->hour == 12) {
+      return 0;
+    }
+    unless ($m->minute == 51) {
+      return 0;
+    }
+    unless ($m->second == 37) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_leap_year : int () {
+    my $m = SPVM::Time::Moment->from_epoch(1582934400);
+    unless ($m->epoch == 1582934400) {
+      return 0;
+    }
+    unless ($m->year == 2020) {
+      return 0;
+    }
+    unless ($m->month == 2) {
+      return 0;
+    }
+    unless ($m->day == 29) {
+      return 0;
+    }
+    unless ($m->day_of_week == SPVM::Time::Moment->SATURDAY) {
+      return 0;
+    }
+    unless ($m->hour == 0) {
+      return 0;
+    }
+    unless ($m->minute == 0) {
+      return 0;
+    }
+    unless ($m->second == 0) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_now : int () {
+    my $eps = 10;
+    my $epoch_now = time();
+    my $now = SPVM::Time::Moment->now;
+    return $epoch_now - $eps <= $now->epoch && $now->epoch + $epoch_now + $eps;
+  }
+}


### PR DESCRIPTION
## SPVM::Time::Format

- `strptime`, `strftime` の機能を持つ
- 時刻は `SPVM::Time::Moment` 型を扱う

```perl
package SPVM::Time::Format {
  has template : string;

  private native sub epoch_by_strptime : long ($buf : string, $format : string);
  private native sub strftime : string ($format : string, $epoch : long);

  sub new : SPVM::Time::Format ($format : string);
  sub parse : SPVM::Time::Moment ($self : self, $string : string);
  sub time_to_str : string ($self : self, $moment : SPVM::Time::Moment);
}
```

## SPVM::Time::Moment

```perl
package SPVM::Time::Moment {
  has epoch : ro long;

  enum {
    MONDAY = 1,
    TUESDAY,
    WEDNESDAY,
    THURSDAY,
    FRIDAY,
    SATURDAY,
    SUNDAY,
  }

  private native sub gmtime : SPVM::Time::tm_9i ($epoch : long); # epoch -> gmtime -> Tm_9i->{tm_year} などを経由して 各 field の値を算出

  sub new_with_epoch : SPVM::Time::Moment ($epoch : long);
  sub from_epoch : SPVM::Time::Moment ($epoch : long); # new_with_epoch と同じ constructor
  sub now : SPVM::Time::Moment (); # gmtime で生成
  sub year : int ($self : self);
  sub month : int ($self : self);
  sub day : int ($self : self);
  sub day_of_week : int ($self : self); # [1=Monday, 7=Sunday]
  sub day_of_year : int ($self : self); # [1, 366]
  sub hour : int ($self : self);
  sub minute : int ($self : self);
  sub second : int ($self : self); # [0, 59]
}
```

## 補足

timezone の扱いをどうすればよいかまとまっておらず、IF は UTCのみ対応しています。
C 言語の `strftime`, `strptime` を使っており、`SPVM::Time::Format->new($format)` に Timezone の `"%Z"` は正しく機能します。