### PR TITLE
[HTTP Headers] SPVM::HTTP::Headers

### DIFF
--- a/lib/SPVM/HTTP/Cookies.spvm
+++ b/lib/SPVM/HTTP/Cookies.spvm
@@ -17,6 +17,40 @@ package SPVM::HTTP::Cookies {
     return $self;
   }
 
+  sub parse_cookie_string : SPVM::HTTP::Cookies ($string : string) {
+    my $self = SPVM::HTTP::Cookies->new;
+    my $str_cookie_length = length($string);
+    my $next_strpos = 0;
+    while ($next_strpos < $str_cookie_length) {
+      my $data = new SPVM::HTTP::Cookies::Data;
+      $data->{key} = "";
+      $data->{value} = "";
+      my $eq_sep_found = 0;
+      for (my $i = $next_strpos; $i < $str_cookie_length; ++$i) {
+        if ($string->[$i] == '=') {
+          $next_strpos = $i + 1;
+          $eq_sep_found = 1;
+          last;
+        } elsif ($string->[$i] != ' ' || length($data->{key})) {
+          $data->{key} .= [$string->[$i]];
+        }
+      }
+      unless ($eq_sep_found) {
+        last;
+      }
+      for (my $i = $next_strpos; $i < $str_cookie_length; ++$i) {
+        if ($string->[$i] == ';') {
+          $next_strpos = $i + 1;
+          last;
+        } else {
+          $data->{value} .= [$string->[$i]];
+        }
+      }
+      $self->set_data($data);
+    }
+    return $self;
+  }
+
   private sub extend_capacity : void ($self : self) {
     my $new_data = new SPVM::HTTP::Cookies::Data[$self->{length} * 2];
     for (my $i = 0; $i < $self->{length}; ++$i) {
@@ -73,13 +107,24 @@ package SPVM::HTTP::Cookies {
     return undef;
   }
 
-  sub to_str : string ($self : self) {
+  sub to_set_cookie_headers : string ($self : self) {
     my $res = "";
     for (my $i = 0; $i < $self->{length}; ++$i) {
-      $res .= $self->{cookies}->[$i]->to_str . "\r\n";
+      if ($i > 0) { $res .= "\r\n"; }
+      $res .= $self->{cookies}->[$i]->to_set_cookie_header;
+    }
+    return $res;
+  }
+
+  sub to_cookie_header : string ($self : self) {
+    my $res = "Cookie: ";
+    for (my $i = 0; $i < $self->{length}; ++$i) {
+      if ($i > 0) { $res .= "; "; }
+      $res .= $self->{cookies}->[$i]->to_cookie_pair;
     }
     return $res;
   }
 }
 __END__
 c.f. https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Set-Cookie
+https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Cookie

--- a/lib/SPVM/HTTP/Cookies.spvm
+++ b/lib/SPVM/HTTP/Cookies.spvm
@@ -1,0 +1,85 @@
+package SPVM::HTTP::Cookies {
+  use SPVM::Hash;
+  use SPVM::StringBuffer;
+  use SPVM::HTTP::Cookies::Data;
+
+  has cookies : SPVM::HTTP::Cookies::Data[];
+  has length : int;
+
+  private sub DEFAULT_CAPACITY : int () {
+    return 3;
+  }
+
+  sub new : SPVM::HTTP::Cookies () {
+    my $self = new SPVM::HTTP::Cookies;
+    $self->{length} = 0;
+    $self->{cookies} = new SPVM::HTTP::Cookies::Data[DEFAULT_CAPACITY()];
+    return $self;
+  }
+
+  private sub extend_capacity : void ($self : self) {
+    my $new_data = new SPVM::HTTP::Cookies::Data[$self->{length} * 2];
+    for (my $i = 0; $i < $self->{length}; ++$i) {
+      $new_data->[$i] = $self->{cookies}->[$i];
+    }
+    $self->{cookies} = $new_data;
+  }
+
+  private sub set_data : void ($self : self, $data : SPVM::HTTP::Cookies::Data) {
+    for (my $i = 0; $i < $self->{length}; ++$i) {
+      if ($data->{key} eq $self->{cookies}->[$i]->{key}) {
+        $self->{cookies}->[$i] = $data;
+        return;
+      }
+    }
+    unless ($self->{length} < @{$self->{cookies}}) {
+      $self->extend_capacity;
+    }
+    $self->{cookies}->[$self->{length}++] = $data;
+  }
+
+  sub set : void ($self : self, $args : SPVM::Hash) {
+    my $data = new SPVM::HTTP::Cookies::Data;
+    $data->{key} = (string)($args->get("key"));
+    $data->{value} = (string)($args->get("value"));
+
+    # optional
+    if ($args->exists("expires")) {
+      $data->{expires} = (SPVM::Time::Moment)($args->get("expires"));
+    }
+    if ($args->exists("max_age")) {
+      $data->{max_age} = ((SPVM::Int)($args->get("max_age")))->val;
+    }
+    $data->{domain} = (string)($args->get("domain"));
+    $data->{path} = (string)($args->get("path"));
+    if ($args->exists("secure") && ((SPVM::Int)($args->get("secure")))->val) {
+      $data->{secure} = 1;
+    }
+    if ($args->exists("http_only") && ((SPVM::Int)($args->get("http_only")))->val) {
+      $data->{http_only} = 1;
+    }
+    if ($args->exists("same_site")) {
+      $data->{same_site} = (byte)(((SPVM::Int)($args->get("same_site")))->val);
+    }
+    $self->set_data($data);
+  }
+
+  sub get : SPVM::HTTP::Cookies::Data ($self : self, $key : string) {
+    for (my $i = 0; $i < $self->{length}; ++$i) {
+      if ($key eq $self->{cookies}->[$i]->{key}) {
+        return $self->{cookies}->[$i];
+      }
+    }
+    return undef;
+  }
+
+  sub to_str : string ($self : self) {
+    my $res = "";
+    for (my $i = 0; $i < $self->{length}; ++$i) {
+      $res .= $self->{cookies}->[$i]->to_str . "\r\n";
+    }
+    return $res;
+  }
+}
+__END__
+c.f. https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Set-Cookie

--- a/lib/SPVM/HTTP/Cookies/Data.spvm
+++ b/lib/SPVM/HTTP/Cookies/Data.spvm
@@ -1,0 +1,60 @@
+package SPVM::HTTP::Cookies::Data : public {
+  use SPVM::Hash;
+  use SPVM::Time::Format;
+  use SPVM::Time::Moment;
+
+  our $TIME_FORMAT : ro SPVM::Time::Format;
+
+  enum {
+    SAME_SITE_NONE,
+    SAME_SITE_STRICT,
+    SAME_SITE_LAX,
+  }
+
+  has key : public string;
+  has value : public string;
+  has expires : public SPVM::Time::Moment;
+  has max_age : public int;
+  has domain : public string;
+  has path : public string;
+  has secure : public int; # FIXME: byte -> Assertion failed: (0), function SPVM_OPCODE_BUILDER_build_opcode_array, file lib/SPVM/Builder/src/spvm_opcode_builder.c, line 3746.
+  has http_only : public int;
+  has same_site : public int;
+
+  BEGIN {
+    $TIME_FORMAT = SPVM::Time::Format->RFC1123;
+  }
+
+  sub to_str : string ($self : self) {
+    my $res = "Set-Cookie: " . $self->{key} . "=" . $self->{value};
+    if ($self->{expires}) {
+      $res .= "; Expires=" . $TIME_FORMAT->time_to_str($self->{expires});
+    }
+    if ($self->{max_age}) {
+      $res .= "; Max-Age=" . $self->{max_age};
+    }
+    if ($self->{domain}) {
+      $res .= "; Domain=" . $self->{domain};
+    }
+    if ($self->{path}) {
+      $res .= "; Path=" . $self->{path};
+    }
+    if ($self->{secure}) {
+      $res .= "; Secure";
+    }
+    if ($self->{http_only}) {
+      $res .= "; HttpOnly";
+    }
+    switch ($self->{same_site}) {
+      case SAME_SITE_STRICT():
+        $res .= "; SameSite=Strict";
+        last;
+      case SAME_SITE_LAX():
+        $res .= "; SameSite=Lax";
+        last;
+      default:
+        last;
+    }
+    return $res;
+  }
+}

--- a/lib/SPVM/HTTP/Cookies/Data.spvm
+++ b/lib/SPVM/HTTP/Cookies/Data.spvm
@@ -25,7 +25,7 @@ package SPVM::HTTP::Cookies::Data : public {
     $TIME_FORMAT = SPVM::Time::Format->RFC1123;
   }
 
-  sub to_str : string ($self : self) {
+  sub to_set_cookie_header : string ($self : self) {
     my $res = "Set-Cookie: " . $self->{key} . "=" . $self->{value};
     if ($self->{expires}) {
       $res .= "; Expires=" . $TIME_FORMAT->time_to_str($self->{expires});
@@ -56,5 +56,9 @@ package SPVM::HTTP::Cookies::Data : public {
         last;
     }
     return $res;
+  }
+
+  sub to_cookie_pair : string ($self : self) {
+    return $self->{key} . "=" . $self->{value};
   }
 }

--- a/lib/SPVM/HTTP/Headers.spvm
+++ b/lib/SPVM/HTTP/Headers.spvm
@@ -1,0 +1,189 @@
+package SPVM::HTTP::Headers {
+  use SPVM::Hash;
+  use SPVM::HTTP::Cookies;
+  use SPVM::Math::StringToNumber;
+  use SPVM::StringBuffer;
+
+  has referer           : ro string;
+  has expires           : ro int;
+  has last_modified     : ro int;
+  has if_modified_since : ro int;
+  has content_type      : ro string;
+  has content_length    : ro int;
+  has content_encoding  : ro string;
+  has cookies           : ro SPVM::HTTP::Cookies;
+  has extra             : ro SPVM::Hash;
+
+  private sub add_header_fallback
+      : void ($self : self, $k : string, $v : string) {
+    unless ($self->{extra}) {
+      $self->{extra} = SPVM::Hash->new;
+    }
+    $self->{extra}->set($k, $v);
+  }
+
+  sub new : SPVM::HTTP::Headers () {
+    my $self = new SPVM::HTTP::Headers;
+    return $self;
+  }
+
+  sub new_with : SPVM::HTTP::Headers ($args : SPVM::Hash) {
+    my $self = new SPVM::HTTP::Headers;
+    if ($args->exists("referer")) {
+      $self->{referer} = (string)($args->get("referer"));
+    }
+    if ($args->exists("expires")) {
+      $self->{expires} = ((SPVM::Int)($args->get("expires")))->val;
+    }
+    if ($args->exists("last_modified")) {
+      $self->{last_modified} = ((SPVM::Int)($args->get("last_modified")))->val;
+    }
+    if ($args->exists("if_modified_since")) {
+      $self->{if_modified_since} = ((SPVM::Int)($args->get("if_modified_since")))->val;
+    }
+    if ($args->exists("content_type")) {
+      $self->{content_type} = (string)($args->get("content_type"));
+    }
+    if ($args->exists("content_length")) {
+      $self->{content_length} = ((SPVM::Int)($args->get("content_length")))->val;
+    }
+    if ($args->exists("content_encoding")) {
+      $self->{content_encoding} = (string)($args->get("content_encoding"));
+    }
+    if ($args->exists("cookies")) {
+      $self->{cookies} = (SPVM::HTTP::Cookies)($args->get("cookies"));
+    }
+    if ($args->exists("extra")) {
+      $self->{extra} = (SPVM::Hash)$args->get("extra");
+    }
+    return $self;
+  }
+
+  sub add_header : void ($self : self, $header : string[]...) {
+    unless (@$header == 2) {
+      croak "Invalid size of args";
+    }
+    my $k = $header->[0];
+    my $v = $header->[1];
+    my $k0 = (int)($k->[0]);
+    switch ($k0) {
+      case 67: #'C':
+        if ($k eq "Content-Type") {
+          $self->{content_type} = $v;
+        } elsif ($k eq "Content-Length") {
+          eval {
+            $self->{content_length} =
+              SPVM::Math::StringToNumber->from($v)->to_int();
+          };
+          if ($@) {
+            warn("Contains non value characters. Exception: " . $@);
+            $@ = undef;
+            return;
+          }
+        } elsif ($k eq "Content-Encoding") {
+          $self->{content_encoding} = $v;
+        } elsif ($k eq "Cookie") {
+          $self->{cookies} = SPVM::HTTP::Cookies->parse_cookie_string($v);
+        } elsif ($k eq "Set-Cookie") {
+          warn("Set-Cookie header is not implemented yet. Ignored.");
+=pod
+          unless ($self->{cookies}) {
+            $self->{cookies} = SPVM::HTTP::Cookies->new;
+          }
+          $self->{cookies}->incr_parse_set_cookie($v);
+=cut
+        } else {
+          $self->add_header_fallback($k, $v);
+        }
+        last;
+      case 73: #'I':
+        if ($k eq "If-Modified-Since") {
+          eval {
+            $self->{if_modified_since} =
+              SPVM::Math::StringToNumber->from($v)->to_int();
+          };
+          if ($@) {
+            warn("Contains non value characters. Exception: " . $@);
+            $@ = undef;
+            return;
+          }
+        } else {
+          $self->add_header_fallback($k, $v);
+        }
+        last;
+      case 76: #'L':
+        if ($k eq "Last-Modified") {
+          eval {
+            $self->{last_modified} =
+              SPVM::Math::StringToNumber->from($v)->to_int();
+          };
+          if ($@) {
+            warn("Contains non value characters. Exception: " . $@);
+            $@ = undef;
+            return;
+          }
+        } else {
+          $self->add_header_fallback($k, $v);
+        }
+        last;
+      case 82: #'R':
+        if ($k eq "Referer" || $k eq "Referrer") {
+          $self->{referer} = $v;
+        } else {
+          $self->add_header_fallback($k, $v);
+        }
+        last;
+      case 69: #'E':
+        if ($k eq "Expires") {
+          eval {
+            $self->{expires} =
+              SPVM::Math::StringToNumber->from($v)->to_int();
+          };
+          if ($@) {
+            warn("Contains non value characters. Exception: " . $@);
+            $@ = undef;
+            return;
+          }
+        } else {
+          $self->add_header_fallback($k, $v);
+        }
+        last;
+      default:
+        $self->add_header_fallback($k, $v);
+        last;
+    }
+  }
+
+  sub append_to_buffer : void ($self : self, $buffer : SPVM::StringBuffer) {
+    if ($self->{referer}) {
+      $buffer->append_string("Referer: " . $self->{referer} . "\r\n");
+    }
+    if ($self->{expires}) {
+      $buffer->append_string("Expires: " . $self->{expires} . "\r\n");
+    }
+    if ($self->{last_modified}) {
+      $buffer->append_string("Last-Modified: " . $self->{last_modified} . "\r\n");
+    }
+    if ($self->{if_modified_since}) {
+      $buffer->append_string("If-Modified-Since: " . $self->{if_modified_since} . "\r\n");
+    }
+    if ($self->{content_type}) {
+      $buffer->append_string("Content-Type: " . $self->{content_type} . "\r\n");
+    }
+    if ($self->{content_length}) {
+      $buffer->append_string("Content-Length: " . $self->{content_length} . "\r\n");
+    }
+    if ($self->{content_encoding}) {
+      $buffer->append_string("Content-Encoding: " . $self->{content_encoding} . "\r\n");
+    }
+    if ($self->{extra}) {
+      my $keys = $self->{extra}->keys();
+      if (@$keys) {
+        for (my $i = 0; $i < @$keys; ++$i) {
+          $buffer->append_string($keys->[$i] . ": " . (string)
+          ($self->{extra}->get($keys->[$i])) . "\r\n");
+        }
+      }
+    }
+  }
+}

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -51,8 +51,6 @@ package SPVM::StringBuffer {
       return SPVM::StringBuffer->new;
     }
     
-    my $string = $self->{value};
-    
     my $new_capacity = $length;
     
     my $new_text = SPVM::StringBuffer->new_with_capacity($new_capacity);
@@ -108,11 +106,35 @@ package SPVM::StringBuffer {
       $self->{length} += $buffer->{length};
     }
     else {
-      
       for (my $i = 0; $i < $buffer->{length}; ++$i) {
         $self->{value}[$self->{length} + $i] = $buffer->{value}->[$i];
       }
       $self->{length} += $buffer->{length};
+    }
+  }
+
+  sub append_string : void ($self : self, $string : string) {
+    my $length = length($string);
+    my $capacity = @$self->{value};
+    if ($self->{length} + $length > $capacity) {
+      # O($new_capacity)
+      my $new_capacity : int;
+      if ($self->{length} + $length > $capacity * 2) {
+        $new_capacity = $self->{length} + $length;
+      } else {
+        $new_capacity = $capacity * 2;
+      }
+      $self->_reallocate($new_capacity);
+      for (my $i = 0; $i < $length; ++$i) {
+        $self->{value}[$self->{length} + $i] = $string->[$i];
+      }
+      $self->{length} += $length;
+    }
+    else {
+      for (my $i = 0; $i < $length; ++$i) {
+        $self->{value}[$self->{length} + $i] = $string->[$i];
+      }
+      $self->{length} += $length;
     }
   }
 
@@ -175,5 +197,9 @@ package SPVM::StringBuffer {
       }
     }
     return 1;
+  }
+
+  sub to_str : string ($self : self) {
+    return (string)(sliceb($self->{value}, 0, $self->{length}));
   }
 }

--- a/lib/SPVM/Time/Format.c
+++ b/lib/SPVM/Time/Format.c
@@ -11,7 +11,7 @@ int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALU
 
   struct tm tm;
   if (!strptime(buf, format, &tm)) {
-    SPVM_CROAK("Can't parse format", "SPVM/Time/Format.c", __LINE__);
+    SPVM_CROAK("Can't parse buffer like format", "SPVM/Time/Format.c", __LINE__);
   }
 
   stack[0].lval = mktime(&tm);
@@ -33,7 +33,7 @@ int32_t SPNATIVE__SPVM__Time__Format__strftime(SPVM_ENV* env, SPVM_VALUE* stack)
 
   if (!strftime(buffer, capacity, format, &dt)) {
     env->dec_ref_count(env, obuffer);
-    SPVM_CROAK("Can't write as format", "SPVM/Time/Format.c", __LINE__);
+    SPVM_CROAK("Can't write like format", "SPVM/Time/Format.c", __LINE__);
   }
 
   int32_t length = sprintf(buffer, "%s", buffer);

--- a/lib/SPVM/Time/Format.c
+++ b/lib/SPVM/Time/Format.c
@@ -1,6 +1,8 @@
 #include "spvm_native.h"
 
+#include <memory.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <time.h>
 
 int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALUE* stack) {
@@ -13,6 +15,34 @@ int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALU
   }
 
   stack[0].lval = mktime(&tm);
+
+  return SPVM_SUCCESS;
+}
+
+int32_t SPNATIVE__SPVM__Time__Format__strftime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  const char* format = (const char*)env->belems(env, stack[0].oval);
+  time_t epoch = stack[1].lval;
+
+  struct tm dt;
+  gmtime_r(&epoch, &dt); // FIXME: only support UTC for now
+
+  int32_t capacity = 100;
+  void* obuffer = env->new_barray_raw(env, capacity);
+  env->inc_ref_count(env, obuffer);
+  char* buffer = (char *)(env->belems(env, obuffer));
+
+  if (!strftime(buffer, capacity, format, &dt)) {
+    env->dec_ref_count(env, obuffer);
+    SPVM_CROAK("Can't write as format", "SPVM/Time/Format.c", __LINE__);
+  }
+
+  int32_t length = sprintf(buffer, "%s", buffer);
+  void* oline = env->new_barray_raw(env, length);
+  int8_t* line = env->belems(env, oline);
+  memcpy(line, buffer, length);
+
+  env->dec_ref_count(env, obuffer);
+  stack[0].oval = oline;
 
   return SPVM_SUCCESS;
 }

--- a/lib/SPVM/Time/Format.c
+++ b/lib/SPVM/Time/Format.c
@@ -7,6 +7,15 @@
 #include <locale.h>
 
 int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  if (!stack[0].oval) {
+    SPVM_CROAK("buffer must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
+  if (!stack[1].oval) {
+    SPVM_CROAK("format must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
+  if (!stack[2].oval) {
+    SPVM_CROAK("locale must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
   const char* buf = (const char*)env->belems(env, stack[0].oval);
   const char* format = (const char*)env->belems(env, stack[1].oval);
   const char* locale = (const char*)env->belems(env, stack[2].oval);
@@ -26,6 +35,12 @@ int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALU
 }
 
 int32_t SPNATIVE__SPVM__Time__Format__strftime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  if (!stack[0].oval) {
+    SPVM_CROAK("format must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
+  if (!stack[2].oval) {
+    SPVM_CROAK("locale must not be undef", "SPVM/Time/Format.c", __LINE__);
+  }
   const char* format = (const char*)env->belems(env, stack[0].oval);
   time_t epoch = stack[1].lval;
   const char* locale = (const char*)env->belems(env, stack[2].oval);

--- a/lib/SPVM/Time/Format.c
+++ b/lib/SPVM/Time/Format.c
@@ -1,0 +1,18 @@
+#include "spvm_native.h"
+
+#include <stdlib.h>
+#include <time.h>
+
+int32_t SPNATIVE__SPVM__Time__Format__epoch_by_strptime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  const char* buf = (const char*)env->belems(env, stack[0].oval);
+  const char* format = (const char*)env->belems(env, stack[1].oval);
+
+  struct tm tm;
+  if (!strptime(buf, format, &tm)) {
+    SPVM_CROAK("Can't parse format", "SPVM/Time/Format.c", __LINE__);
+  }
+
+  stack[0].lval = mktime(&tm);
+
+  return SPVM_SUCCESS;
+}

--- a/lib/SPVM/Time/Format.spvm
+++ b/lib/SPVM/Time/Format.spvm
@@ -1,23 +1,32 @@
 package SPVM::Time::Format {
   use SPVM::Time::Moment;
 
-  has template : string;
+  has format : ro string;
+  has locale : ro string;
 
-  private native sub epoch_by_strptime : long ($buf : string, $format : string);
-  private native sub strftime : string ($format : string, $epoch : long);
+  private native sub epoch_by_strptime : long ($buf : string, $format : string, $locale : string);
+  private native sub strftime : string ($format : string, $epoch : long, $locale : string);
 
   sub new : SPVM::Time::Format ($format : string) {
     my $self = new SPVM::Time::Format;
-    $self->{template} = $format;
+    $self->{format} = $format;
+    $self->{locale} = "C";
+    return $self;
+  }
+
+  sub RFC1123 : SPVM::Time::Format () {
+    my $self = new SPVM::Time::Format;
+    $self->{format} = "%a, %d %b %Y %H:%M:%S %Z"; # using gmtime_r is expected in strftime.
+    $self->{locale} = "C";
     return $self;
   }
 
   sub parse : SPVM::Time::Moment ($self : self, $string : string) {
-    my $epoch = SPVM::Time::Format->epoch_by_strptime($string, $self->{template});
+    my $epoch = SPVM::Time::Format->epoch_by_strptime($string, $self->{format}, $self->{locale});
     return SPVM::Time::Moment->from_epoch($epoch);
   }
 
   sub time_to_str : string ($self : self, $moment : SPVM::Time::Moment) {
-    return SPVM::Time::Format->strftime($self->{template}, $moment->epoch);
+    return SPVM::Time::Format->strftime($self->{format}, $moment->epoch, $self->{locale});
   }
 }

--- a/lib/SPVM/Time/Format.spvm
+++ b/lib/SPVM/Time/Format.spvm
@@ -4,6 +4,7 @@ package SPVM::Time::Format {
   has template : string;
 
   private native sub epoch_by_strptime : long ($buf : string, $format : string);
+  private native sub strftime : string ($format : string, $epoch : long);
 
   sub new : SPVM::Time::Format ($format : string) {
     my $self = new SPVM::Time::Format;
@@ -14,5 +15,9 @@ package SPVM::Time::Format {
   sub parse : SPVM::Time::Moment ($self : self, $string : string) {
     my $epoch = SPVM::Time::Format->epoch_by_strptime($string, $self->{template});
     return SPVM::Time::Moment->from_epoch($epoch);
+  }
+
+  sub time_to_str : string ($self : self, $moment : SPVM::Time::Moment) {
+    return SPVM::Time::Format->strftime($self->{template}, $moment->epoch);
   }
 }

--- a/lib/SPVM/Time/Format.spvm
+++ b/lib/SPVM/Time/Format.spvm
@@ -1,0 +1,18 @@
+package SPVM::Time::Format {
+  use SPVM::Time::Moment;
+
+  has template : string;
+
+  private native sub epoch_by_strptime : long ($buf : string, $format : string);
+
+  sub new : SPVM::Time::Format ($format : string) {
+    my $self = new SPVM::Time::Format;
+    $self->{template} = $format;
+    return $self;
+  }
+
+  sub parse : SPVM::Time::Moment ($self : self, $string : string) {
+    my $epoch = SPVM::Time::Format->epoch_by_strptime($string, $self->{template});
+    return SPVM::Time::Moment->from_epoch($epoch);
+  }
+}

--- a/lib/SPVM/Time/Moment.c
+++ b/lib/SPVM/Time/Moment.c
@@ -1,0 +1,46 @@
+#include "spvm_native.h"
+
+#include <stdlib.h>
+#include <time.h>
+
+// FIXME: Remove duplication between Moment.c and Format.c
+int32_t SPNATIVE__SPVM__Time__Moment__strptime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  const char* buf = (const char*)env->belems(env, stack[0].oval);
+  const char* format = (const char*)env->belems(env, stack[1].oval);
+
+  struct tm dt;
+  if (!strptime(buf, format, &dt)) {
+    return SPVM_EXCEPTION;
+  }
+
+  stack[0].ival = dt.tm_sec;
+  stack[1].ival = dt.tm_min;
+  stack[2].ival = dt.tm_hour;
+  stack[3].ival = dt.tm_mday;
+  stack[4].ival = dt.tm_mon;
+  stack[5].ival = dt.tm_year;
+  stack[6].ival = dt.tm_wday;
+  stack[7].ival = dt.tm_yday;
+  stack[8].ival = dt.tm_isdst;
+
+  return SPVM_SUCCESS;
+}
+
+int32_t SPNATIVE__SPVM__Time__Moment__gmtime(SPVM_ENV* env, SPVM_VALUE* stack) {
+  time_t epoch = stack[0].lval;
+
+  struct tm dt;
+  gmtime_r(&epoch, &dt);
+
+  stack[0].ival = dt.tm_sec;
+  stack[1].ival = dt.tm_min;
+  stack[2].ival = dt.tm_hour;
+  stack[3].ival = dt.tm_mday;
+  stack[4].ival = dt.tm_mon;
+  stack[5].ival = dt.tm_year;
+  stack[6].ival = dt.tm_wday;
+  stack[7].ival = dt.tm_yday;
+  stack[8].ival = dt.tm_isdst;
+
+  return SPVM_SUCCESS;
+}

--- a/lib/SPVM/Time/Moment.spvm
+++ b/lib/SPVM/Time/Moment.spvm
@@ -1,0 +1,74 @@
+package SPVM::Time::Moment {
+  use SPVM::Time::tm_9i;
+
+  has epoch : ro long;
+
+  enum {
+    MONDAY = 1,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY,
+  }
+
+  private native sub gmtime : SPVM::Time::tm_9i ($epoch : long);
+
+  sub new_with_epoch : SPVM::Time::Moment ($epoch : long) {
+    return SPVM::Time::Moment->from_epoch($epoch);
+  }
+
+  sub from_epoch : SPVM::Time::Moment ($epoch : long) {
+    my $self = new SPVM::Time::Moment;
+    $self->{epoch} = $epoch;
+    return $self;
+  }
+
+  sub now : SPVM::Time::Moment () {
+    return SPVM::Time::Moment->from_epoch(time());
+  }
+
+  # TODO: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_16
+  # sub new_with : SPVM::Time::Moment ($args : SPVM::Hash) {}
+
+  sub new_with_offset_same_instant : SPVM::Time::Moment ($self : SPVM::Time::Moment, $offset_minutes : int) {
+    return SPVM::Time::Moment->from_epoch($self->epoch + $offset_minutes * 60);
+  }
+
+  #sub new_with_offset_same_local : SPVM::Time::Moment ($base : SPVM::Time::Moment) {
+  #  return new SPVM::Time::Moment;
+  #}
+
+  sub year : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_year} + 1900;
+  }
+
+  sub month : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_mon} + 1;
+  }
+
+  sub day : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_mday};
+  }
+
+  sub day_of_week : int ($self : self) { # [1=Monday, 7=Sunday]
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_wday};
+  }
+
+  sub day_of_year : int ($self : self) { # [1, 366]
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_yday} + 1;
+  }
+
+  sub hour : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_hour};
+  }
+
+  sub minute : int ($self : self) {
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_min};
+  }
+
+  sub second : int ($self : self) { # [0, 59]
+    return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_sec};
+  }
+}

--- a/lib/SPVM/Time/Moment.spvm
+++ b/lib/SPVM/Time/Moment.spvm
@@ -32,14 +32,6 @@ package SPVM::Time::Moment {
   # TODO: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_16
   # sub new_with : SPVM::Time::Moment ($args : SPVM::Hash) {}
 
-  sub new_with_offset_same_instant : SPVM::Time::Moment ($self : SPVM::Time::Moment, $offset_minutes : int) {
-    return SPVM::Time::Moment->from_epoch($self->epoch + $offset_minutes * 60);
-  }
-
-  #sub new_with_offset_same_local : SPVM::Time::Moment ($base : SPVM::Time::Moment) {
-  #  return new SPVM::Time::Moment;
-  #}
-
   sub year : int ($self : self) {
     return SPVM::Time::Moment->gmtime($self->{epoch})->{tm_year} + 1900;
   }

--- a/lib/SPVM/Time/tm_9i.spvm
+++ b/lib/SPVM/Time/tm_9i.spvm
@@ -1,0 +1,11 @@
+package SPVM::Time::tm_9i : value_t {
+  has tm_sec : int;
+  has tm_min : int;
+  has tm_hour : int;
+  has tm_mday : int;
+  has tm_mon : int;
+  has tm_year : int;
+  has tm_wday : int;
+  has tm_yday : int;
+  has tm_isdst : int;
+}

--- a/t/default/lib-SPVM-HTTP-Cookies.t
+++ b/t/default/lib-SPVM-HTTP-Cookies.t
@@ -1,0 +1,22 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::HTTP::Cookies';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::HTTP::Cookies
+{
+  ok(TestCase::Lib::SPVM::HTTP::Cookies->test_all_through);
+  ok(TestCase::Lib::SPVM::HTTP::Cookies->test_extend_capacity);
+}
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-HTTP-Cookies.t
+++ b/t/default/lib-SPVM-HTTP-Cookies.t
@@ -15,6 +15,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 {
   ok(TestCase::Lib::SPVM::HTTP::Cookies->test_all_through);
   ok(TestCase::Lib::SPVM::HTTP::Cookies->test_extend_capacity);
+  ok(TestCase::Lib::SPVM::HTTP::Cookies->test_parse_cookie_string);
 }
 
 # All object is freed

--- a/t/default/lib-SPVM-HTTP-Headers.t
+++ b/t/default/lib-SPVM-HTTP-Headers.t
@@ -1,0 +1,23 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::HTTP::Headers';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::HTTP::Headers
+{
+  ok(TestCase::Lib::SPVM::HTTP::Headers->test_new_with);
+  ok(TestCase::Lib::SPVM::HTTP::Headers->test_add_header);
+  ok(TestCase::Lib::SPVM::HTTP::Headers->test_append_to_buffer);
+}
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-StringBuffer.t
+++ b/t/default/lib-SPVM-StringBuffer.t
@@ -20,9 +20,11 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::Lib::SPVM::StringBuffer->test_substr);
   ok(TestCase::Lib::SPVM::StringBuffer->test_prepend);
   ok(TestCase::Lib::SPVM::StringBuffer->test_append);
+  ok(TestCase::Lib::SPVM::StringBuffer->test_append_string);
   ok(TestCase::Lib::SPVM::StringBuffer->test_replace);
   ok(TestCase::Lib::SPVM::StringBuffer->test_to_barray);
   ok(TestCase::Lib::SPVM::StringBuffer->test_equals);
+  ok(TestCase::Lib::SPVM::StringBuffer->test_to_str);
 }
 
 # All object is freed

--- a/t/default/lib-SPVM-Time-Format.t
+++ b/t/default/lib-SPVM-Time-Format.t
@@ -14,6 +14,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 # SPVM::Time::Format
 {
   ok(TestCase::Lib::SPVM::Time::Format->test_parse());
+  ok(TestCase::Lib::SPVM::Time::Format->test_timezone_JST());
 }
 
 

--- a/t/default/lib-SPVM-Time-Format.t
+++ b/t/default/lib-SPVM-Time-Format.t
@@ -15,6 +15,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 {
   ok(TestCase::Lib::SPVM::Time::Format->test_parse());
   ok(TestCase::Lib::SPVM::Time::Format->test_time_to_str());
+  ok(TestCase::Lib::SPVM::Time::Format->test_RFC1123());
   ok(TestCase::Lib::SPVM::Time::Format->test_timezone_JST());
 }
 

--- a/t/default/lib-SPVM-Time-Format.t
+++ b/t/default/lib-SPVM-Time-Format.t
@@ -14,6 +14,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 # SPVM::Time::Format
 {
   ok(TestCase::Lib::SPVM::Time::Format->test_parse());
+  ok(TestCase::Lib::SPVM::Time::Format->test_time_to_str());
   ok(TestCase::Lib::SPVM::Time::Format->test_timezone_JST());
 }
 

--- a/t/default/lib-SPVM-Time-Format.t
+++ b/t/default/lib-SPVM-Time-Format.t
@@ -1,0 +1,22 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::Time::Format';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::Time::Format
+{
+  ok(TestCase::Lib::SPVM::Time::Format->test_parse());
+}
+
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-Time-Moment.t
+++ b/t/default/lib-SPVM-Time-Moment.t
@@ -1,0 +1,24 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::Time::Moment';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::Time::Moment
+{
+  ok(TestCase::Lib::SPVM::Time::Moment->test_basic());
+  ok(TestCase::Lib::SPVM::Time::Moment->test_leap_year());
+  ok(TestCase::Lib::SPVM::Time::Moment->test_now());
+}
+
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/Cookies.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/Cookies.spvm
@@ -1,0 +1,58 @@
+package TestCase::Lib::SPVM::HTTP::Cookies {
+  use SPVM::HTTP::Cookies;
+
+  sub test_all_through : int () {
+    my $cookies = SPVM::HTTP::Cookies->new;
+    if ($cookies->get("field")) {
+      return 0;
+    }
+    $cookies->set(new_hash([(object)
+      key   => "field1",
+      value => "value1",
+    ]));
+    unless ($cookies->get("field1")->{value} eq "value1") {
+      return 0;
+    }
+    $cookies->set(new_hash([(object)
+      key   => "field2",
+      value => "value2",
+    ]));
+    unless ($cookies->get("field1")->{value} eq "value1") {
+      return 0;
+    }
+    unless ($cookies->get("field2")->{value} eq "value2") {
+      return 0;
+    }
+    $cookies->set(new_hash([(object)
+      key   => "field1",
+      value => "value1-2",
+    ]));
+    unless ($cookies->get("field1")->{value} eq "value1-2") {
+      return 0;
+    }
+    my $got_str = $cookies->to_str;
+    my $expected_str = "Set-Cookie: field1=value1-2\r\n" .
+      "Set-Cookie: field2=value2\r\n";
+    unless ($got_str eq $expected_str) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_extend_capacity : int () {
+    my $cookies = SPVM::HTTP::Cookies->new;
+    for (my $i = 0; $i < 32; ++$i) {
+      $cookies->set(new_hash([(object)
+        key   => (string)[(byte)('A' + $i)],
+        value => (string)['V', (byte)('A' + $i)],
+      ]));
+    }
+    for (my $i = 0; $i < 32; ++$i) {
+      my $data = $cookies->get((string)[(byte)('A' + $i)]);
+      unless ($data->{value} eq (string)['V', (byte)('A' + $i)]) {
+        return 0;
+      }
+    }
+    return 1;
+  }
+}

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/Cookies.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/Cookies.spvm
@@ -30,11 +30,20 @@ package TestCase::Lib::SPVM::HTTP::Cookies {
     unless ($cookies->get("field1")->{value} eq "value1-2") {
       return 0;
     }
-    my $got_str = $cookies->to_str;
-    my $expected_str = "Set-Cookie: field1=value1-2\r\n" .
-      "Set-Cookie: field2=value2\r\n";
-    unless ($got_str eq $expected_str) {
-      return 0;
+    {
+      my $got = $cookies->to_set_cookie_headers;
+      my $expected = "Set-Cookie: field1=value1-2\r\n" .
+          "Set-Cookie: field2=value2";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $got = $cookies->to_cookie_header;
+      my $expected = "Cookie: field1=value1-2; field2=value2";
+      unless ($got eq $expected) {
+        return 0;
+      }
     }
     return 1;
   }
@@ -52,6 +61,23 @@ package TestCase::Lib::SPVM::HTTP::Cookies {
       unless ($data->{value} eq (string)['V', (byte)('A' + $i)]) {
         return 0;
       }
+    }
+    return 1;
+  }
+
+  sub test_parse_cookie_string : int () {
+    my $cookies = SPVM::HTTP::Cookies->parse_cookie_string("foo=fuga; piyo=poyo; bar=hoge; bar=baz");
+    unless ($cookies->get("foo")->{value} eq "fuga") {
+      return 0;
+    }
+    unless ($cookies->get("piyo")->{value} eq "poyo") {
+      return 0;
+    }
+    unless ($cookies->get("bar")->{value} eq "baz") {
+      return 0;
+    }
+    unless ($cookies->get("none") == undef) {
+      return 0;
     }
     return 1;
   }

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/Headers.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/Headers.spvm
@@ -1,0 +1,233 @@
+package TestCase::Lib::SPVM::HTTP::Headers {
+  use SPVM::HTTP::Cookies;
+  use SPVM::HTTP::Headers;
+  use SPVM::StringBuffer;
+  use SPVM::List;
+  use SPVM::Math::StringToNumber;
+
+  our $REQUEST_HEADERS : string[];
+  our $ENTITY_HEADERS : string[];
+  our $RESERVED : string[];
+
+  BEGIN {
+    $REQUEST_HEADERS= [
+      "Accept", "Accept-Charset", "Accept-Encoding", "Accept-Language",
+      "Authorization", "Expect", "From", "Host",
+      "If-Match", "If-Modified-Since", "If-None-Match", "If-Range", "If-Unmodified-Since",
+      "Max-Forwards", "Proxy-Authorization", "Range", "Referer", "TE", "User-Agent",
+    ];
+    $ENTITY_HEADERS = [
+      "Allow", "Content-Encoding", "Content-Language", "Content-Length", "Content-Location",
+      "Content-MD5", "Content-Range", "Content-Type", "Expires", "Last-Modified",
+    ];
+    $RESERVED = [
+      "Referer", "Expires", "Last-Modified", "If-Modified-Since", "Content-Type",
+      "Content-Length", "Content-Encoding",
+    ];
+  }
+
+  private sub in_reserved : int ($key : string) {
+    for (my $i = 0; $i < @$RESERVED; ++$i) {
+      if ($key eq $RESERVED->[$i]) {
+        return 1;
+      }
+    }
+    return 0;
+  }
+
+  sub test_add_header : int () {
+    my $headers = SPVM::HTTP::Headers->new;
+    # Referer param also allows Referrer
+    $headers->add_header("Referrer", "referrer");
+    unless ($headers->referer eq "referrer") {
+      return 0;
+    }
+    for (my $i = 0; $i < @$REQUEST_HEADERS; ++$i) {
+      $headers->add_header($REQUEST_HEADERS->[$i], "12345678");
+    }
+    for (my $i = 0; $i < @$ENTITY_HEADERS; ++$i) {
+      $headers->add_header($ENTITY_HEADERS->[$i], "12345678");
+    }
+    unless ($headers->referer eq "12345678") {
+      return 0;
+    }
+    unless ($headers->expires == 12345678) {
+      return 0;
+    }
+    unless ($headers->last_modified == 12345678) {
+      return 0;
+    }
+    unless ($headers->if_modified_since == 12345678) {
+      return 0;
+    }
+    unless ($headers->content_type eq "12345678") {
+      return 0;
+    }
+    unless ($headers->content_length == 12345678) {
+      return 0;
+    }
+    unless ($headers->content_encoding eq "12345678") {
+      return 0;
+    }
+    for (my $i = 0; $i < @$REQUEST_HEADERS; ++$i) {
+      unless (in_reserved($REQUEST_HEADERS->[$i])) {
+        my $got = (string)($headers->extra->get($REQUEST_HEADERS->[$i]));
+        my $expected = "12345678";
+        unless ($got eq $expected) {
+          warn("Some header doesn't match.\n     got: '$got'\nexpected: '$expected'");
+          return 0;
+        }
+      }
+    }
+    for (my $i = 0; $i < @$ENTITY_HEADERS; ++$i) {
+      unless (in_reserved($ENTITY_HEADERS->[$i])) {
+        my $got = (string)($headers->extra->get($ENTITY_HEADERS->[$i]));
+        my $expected = "12345678";
+        unless ($got eq $expected) {
+          warn("Some header doesn't match.\n     got: '" . (string)$got . "'\nexpected: '$expected'");
+          return 0;
+        }
+      }
+    }
+    return 1;
+  }
+
+  sub _test_bag_strarray : int ($lhs : string[], $rhs : string[]) {
+    unless (@$lhs == @$rhs) {
+      warn("array sizes do not match.\n" .
+        "\tlength lhs: " . @$lhs . " " .
+        "\tlength rhs: " . @$rhs);
+      return 0;
+    }
+    sorto($lhs, sub : int ($self : self, $left : object, $right : object) {
+      if ((string)$left gt (string)$right) {
+        return 1;
+      }
+      return 0;
+    });
+    sorto($rhs, sub : int ($self : self, $left : object, $right : object) {
+      if ((string)$left gt (string)$right) {
+        return 1;
+      }
+      return 0;
+    });
+    for (my $i = 0; $i < @$lhs; ++$i) {
+      unless ($lhs->[$i] eq $rhs->[$i]) {
+        warn("_test_bag_strarray failed at:\n" .
+            "\tlhs: '" . $lhs->[$i] . "'\n" .
+            "\trhs: '" . $rhs->[$i] . "'");
+        return 0;
+      }
+    }
+    return 1;
+  }
+
+  sub test_new_with : int () {
+    my $val = "12345678";
+    my $val_i = SPVM::Math::StringToNumber->from($val)->to_int;
+    my $cookies = SPVM::HTTP::Cookies->new;
+    $cookies->set(new_hash([(object)
+      key => "foo", value => "bar",
+    ]));
+    my $headers = SPVM::HTTP::Headers->new_with(new_hash([(object)
+      referer           => $val,
+      expires           => $val_i,
+      last_modified     => $val_i,
+      if_modified_since => $val_i,
+      content_type      => $val,
+      content_length    => $val_i,
+      content_encoding  => $val,
+      cookies           => $cookies,
+      extra             => new_hash([(object) "X-Bearer" => "XXXXX"]),
+    ]));
+    unless ($headers->referer eq $val) {
+      return 0;
+    }
+    unless (((SPVM::Int)($headers->expires))->val == $val_i) {
+      return 0;
+    }
+    unless (((SPVM::Int)($headers->last_modified))->val == $val_i) {
+      return 0;
+    }
+    unless (((SPVM::Int)($headers->if_modified_since))->val == $val_i) {
+      return 0;
+    }
+    unless ($headers->content_type eq $val) {
+      return 0;
+    }
+    unless (((SPVM::Int)($headers->content_length))->val == $val_i) {
+      return 0;
+    }
+    unless ($headers->content_encoding eq $val) {
+      return 0;
+    }
+    unless ($headers->cookies->get("foo")->{value} eq "bar") {
+      return 0;
+    }
+    unless ((string)($headers->extra->get("X-Bearer")) eq "XXXXX") {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_append_to_buffer : int () {
+    my $val = "12345678";
+    my $got_list = SPVM::List->new;
+    {
+      my $headers = SPVM::HTTP::Headers->new;
+      my $buf = SPVM::StringBuffer->new;
+      for (my $i = 0; $i < @$REQUEST_HEADERS; ++$i) {
+        $headers->add_header($REQUEST_HEADERS->[$i], $val);
+      }
+      for (my $i = 0; $i < @$ENTITY_HEADERS; ++$i) {
+        $headers->add_header($ENTITY_HEADERS->[$i], $val);
+      }
+      $headers->append_to_buffer($buf);
+      my $got_barray = $buf->to_barray();
+
+      my $last = 0;
+      for (my $i = 0; $i < @$got_barray; ++$i) {
+        if ($i > 0 && $got_barray->[$i - 1] == '\r' && $got_barray->[$i] == '\n') {
+          my $line = (string)(sliceb($got_barray, $last, $i + 1 - $last));
+          $got_list->push((string)(sliceb($got_barray, $last, $i + 1 - $last)));
+          $last = $i + 1;
+        }
+      }
+      unless (@$got_barray == $last) {
+        warn("Request Headers must end with CRLF:\n\tgot: '" . $got_barray . "'\n" .
+          "\tlast: $last\n" .
+          "\tgot_barray size: " . @$got_barray);
+        return 0;
+      }
+    }
+
+    my $expected_list = SPVM::List->new;
+    {
+      my $used = SPVM::Hash->new;
+      for (my $i = 0; $i < @$RESERVED; ++$i) {
+        my $key = $RESERVED->[$i];
+        $expected_list->push($key . ": $val\r\n");
+        $used->set($key, 1);
+      }
+      for (my $i = 0; $i < @$REQUEST_HEADERS; ++$i) {
+        my $key = $REQUEST_HEADERS->[$i];
+        unless ($used->exists($key)) {
+          $expected_list->push($key . ": $val\r\n");
+          $used->set($key, 1);
+        }
+      }
+      for (my $i = 0; $i < @$ENTITY_HEADERS; ++$i) {
+        my $key = $ENTITY_HEADERS->[$i];
+        unless ($used->exists($key)) {
+          $expected_list->push($key . ": $val\r\n");
+        }
+      }
+    }
+
+    unless (_test_bag_strarray($got_list->to_strarray, $expected_list->to_strarray)) {
+      warn("Request Headers do not match.");
+      return 0;
+    }
+    return 1;
+  }
+}

--- a/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
@@ -228,6 +228,26 @@ package TestCase::Lib::SPVM::StringBuffer {
     return 1;
   }
 
+  sub test_append_string : int () {
+    my $buffer = SPVM::StringBuffer->new_with_capacity(1);
+    $buffer->append_string("abc");
+    unless ($buffer->to_barray eq "abc" && $buffer->capacity == 3) {
+      warn("actual string: " . $buffer->to_barray . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->append_string("de");
+    unless ($buffer->to_barray eq "abcde" && $buffer->capacity == 6) {
+      warn("actual string: " . $buffer->to_barray . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->append_string("f");
+    unless ($buffer->to_barray eq "abcdef" && $buffer->capacity == 6) {
+      warn("actual string: " . $buffer->to_barray . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    return 1;
+  }
+
   sub test_append_copy_on_write : int () {
     warn("TODO: append copy-on-write test is not implemented yet");
     return 0;
@@ -317,6 +337,24 @@ package TestCase::Lib::SPVM::StringBuffer {
     }
     unless (!$lhs->equals(SPVM::StringBuffer->new_with_string("ab"))) {
       return 0;
+    }
+    return 1;
+  }
+
+  sub test_to_str : int () {
+    {
+      my $minimal_buf = SPVM::StringBuffer->new_with_capacity(1);
+      $minimal_buf->append_string("a");
+      unless ($minimal_buf->to_str eq "a") {
+        return 0;
+      }
+    }
+    {
+      my $large_buf = SPVM::StringBuffer->new_with_capacity(1000000);
+      $large_buf->append_string("b");
+      unless ($large_buf->to_str eq "b") {
+        return 0;
+      }
     }
     return 1;
   }

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
@@ -1,5 +1,6 @@
 package TestCase::Lib::SPVM::Time::Format {
   use SPVM::Time::Format;
+  use SPVM::Time::Moment;
 
   sub test_parse : int () {
     my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
@@ -32,6 +33,12 @@ package TestCase::Lib::SPVM::Time::Format {
       return 0;
     }
     return 1;
+  }
+
+  sub test_time_to_str : int () {
+    my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
+    my $output = $format->time_to_str(SPVM::Time::Moment->from_epoch(1553518297));
+    return $output eq "2019-03-25 12:51:37 UTC";
   }
 
   sub test_timezone_JST : int () {

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
@@ -1,0 +1,35 @@
+package TestCase::Lib::SPVM::Time::Format {
+  use SPVM::Time::Format;
+  sub test_parse : int () {
+    my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
+    my $m = $format->parse("2019-03-25 12:51:37 GMT");
+    unless ($m->epoch == 1553518297) {
+      return 0;
+    }
+    unless ($m->year == 2019) {
+      return 0;
+    }
+    unless ($m->month == 3) {
+      return 0;
+    }
+    unless ($m->day == 25) {
+      return 0;
+    }
+    unless ($m->day_of_week == SPVM::Time::Moment->MONDAY) {
+      return 0;
+    }
+    unless ($m->day_of_year == 84) {
+      return 0;
+    }
+    unless ($m->hour == 12) {
+      return 0;
+    }
+    unless ($m->minute == 51) {
+      return 0;
+    }
+    unless ($m->second == 37) {
+      return 0;
+    }
+    return 1;
+  }
+}

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
@@ -1,5 +1,6 @@
 package TestCase::Lib::SPVM::Time::Format {
   use SPVM::Time::Format;
+
   sub test_parse : int () {
     my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
     my $m = $format->parse("2019-03-25 12:51:37 GMT");
@@ -31,5 +32,11 @@ package TestCase::Lib::SPVM::Time::Format {
       return 0;
     }
     return 1;
+  }
+
+  sub test_timezone_JST : int () {
+    my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
+    my $m = $format->parse("2019-03-25 12:51:37 JST");
+    return $m->epoch == 1553485897;
   }
 }

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Format.spvm
@@ -35,6 +35,18 @@ package TestCase::Lib::SPVM::Time::Format {
     return 1;
   }
 
+  sub test_RFC1123 : int () {
+    my $format = SPVM::Time::Format->RFC1123;
+    unless ($format->parse("Wed, 02 Jan 2030 03:04:56 GMT")->epoch == 1893553496) { # TODO: Allow UTC
+      return 0;
+    }
+    unless ($format->time_to_str(SPVM::Time::Moment->from_epoch(1893553496)) eq "Wed, 02 Jan 2030 03:04:56 UTC") {
+      warn ($format->time_to_str(SPVM::Time::Moment->from_epoch(1893553496)));
+      return 0;
+    }
+    return 1;
+  }
+
   sub test_time_to_str : int () {
     my $format = SPVM::Time::Format->new("%Y-%m-%d %H:%M:%S %Z");
     my $output = $format->time_to_str(SPVM::Time::Moment->from_epoch(1553518297));

--- a/t/default/lib/TestCase/Lib/SPVM/Time/Moment.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Time/Moment.spvm
@@ -1,0 +1,73 @@
+package TestCase::Lib::SPVM::Time::Moment {
+  use SPVM::Time::Moment;
+
+  sub test_basic : int () {
+    # UTC: 2019/3/25 Monday 12:51:37
+    my $m = SPVM::Time::Moment->from_epoch(1553518297);
+    unless ($m->epoch == 1553518297) {
+      return 0;
+    }
+    unless ($m->year == 2019) {
+      return 0;
+    }
+    unless ($m->month == 3) {
+      return 0;
+    }
+    unless ($m->day == 25) {
+      return 0;
+    }
+    unless ($m->day_of_week == SPVM::Time::Moment->MONDAY && SPVM::Time::Moment->MONDAY == 1) {
+      return 0;
+    }
+    # perl -MDateTime -le 'my $dt = DateTime->from_epoch(epoch => 1553518297); print $dt->day_of_year'
+    unless ($m->day_of_year == 84) {
+      return 0;
+    }
+    unless ($m->hour == 12) {
+      return 0;
+    }
+    unless ($m->minute == 51) {
+      return 0;
+    }
+    unless ($m->second == 37) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_leap_year : int () {
+    my $m = SPVM::Time::Moment->from_epoch(1582934400);
+    unless ($m->epoch == 1582934400) {
+      return 0;
+    }
+    unless ($m->year == 2020) {
+      return 0;
+    }
+    unless ($m->month == 2) {
+      return 0;
+    }
+    unless ($m->day == 29) {
+      return 0;
+    }
+    unless ($m->day_of_week == SPVM::Time::Moment->SATURDAY) {
+      return 0;
+    }
+    unless ($m->hour == 0) {
+      return 0;
+    }
+    unless ($m->minute == 0) {
+      return 0;
+    }
+    unless ($m->second == 0) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub test_now : int () {
+    my $eps = 10;
+    my $epoch_now = time();
+    my $now = SPVM::Time::Moment->now;
+    return $epoch_now - $eps <= $now->epoch && $now->epoch + $epoch_now + $eps;
+  }
+}


### PR DESCRIPTION
```perl
package SPVM::HTTP::Headers {
  has referer           : ro string;
  has expires           : ro int;
  has last_modified     : ro int;
  has if_modified_since : ro int;
  has content_type      : ro string;
  has content_length    : ro int;
  has content_encoding  : ro string;
  has cookies           : ro SPVM::HTTP::Cookies;
  has extra             : ro SPVM::Hash;

  sub new : SPVM::HTTP::Headers ();
  sub new_with : SPVM::HTTP::Headers ($args : SPVM::Hash);
  sub add_header : void ($self : self, $header : string[]...); # string 形式で key-value のヘッダを受け取り、フィールドの要素に変換(cookie などはオブジェクトにパース)する
  sub append_to_buffer : void ($self : self, $buffer : SPVM::StringBuffer); # to_str の代わり. HTTP Request の文字列を作成するときに StringBuffer を用いるため.
}
```