### PR TITLE
Fix GET/HEAD request

### DIFF
--- a/lib/SPVM/HTTP/Client.spvm
+++ b/lib/SPVM/HTTP/Client.spvm
@@ -15,7 +15,7 @@ package SPVM::HTTP::Client {
     return $self;
   }
 
-  sub new_with : SPVM::HTTP::Client ($args : SPVM::Hash) {
+  sub new_opt : SPVM::HTTP::Client ($args : SPVM::Hash) {
     my $self = new SPVM::HTTP::Client;
     $self->{default_headers} = SPVM::Hash->newa([]);
     $self->{timeout} = 60;
@@ -24,7 +24,7 @@ package SPVM::HTTP::Client {
 
   private sub _prepare_headers : SPVM::Hash ($self : self, $host : string, $port : int) {
     my $headers = $self->{default_headers};
-    if ($port) {
+    if ($port && $port != 80) {
       $host .= ":$port";
     }
     $headers->set("Host", $host);
@@ -33,7 +33,7 @@ package SPVM::HTTP::Client {
 
   private sub _open_handle : SPVM::HTTP::Client::Handle ($self : self,
       $host : string, $port : int) {
-    my $handle = SPVM::HTTP::Client::Handle->new_with(SPVM::Hash->newa([(object)
+    my $handle = SPVM::HTTP::Client::Handle->new_opt(SPVM::Hash->newa([(object)
       timeout => $self->{timeout},
     ]));
     return $handle->connect(SPVM::Hash->newa([(object)
@@ -50,8 +50,8 @@ package SPVM::HTTP::Client {
     my $host = $u->{host};
     my $port = $u->{port};
     my $path_query = $u->{path};
-    if ($u->{params}) {
-      $path_query .= "?" . $u->to_str;
+    if ($u->{params} && $u->{params}->to_str ne "") {
+      $path_query .= "?" . $u->{params}->to_str;
     }
     my $headers = $self->_prepare_headers($host, $port);
     my $handle = $self->_open_handle($host, $port);
@@ -83,7 +83,18 @@ package SPVM::HTTP::Client {
         }
       }
     }
-    my $known_message_length = $handle->read_body($response);
+    my $known_message_length : int;
+    if ($method eq "HEAD" || ($response->{status} == 204 || $response->{status} == 304)) {
+      $known_message_length = 1;
+    }
+    else {
+      $known_message_length = $handle->read_body($response);
+    }
+
+    $response->{success} = $response->{status} / 100 == 2;
+    $response->{url} = $url;
+
+    # Output content to a temporary file.
     {
       my $tmpfile = "t/test_files_tmp/client_content.html";
       warn("\nWrite content in '$tmpfile'");
@@ -115,7 +126,7 @@ package SPVM::HTTP::Client::Handle {
     $_BUFSIZE = 32768;
   }
 
-  sub new_with : SPVM::HTTP::Client::Handle ($args : SPVM::Hash) {
+  sub new_opt : SPVM::HTTP::Client::Handle ($args : SPVM::Hash) {
     my $self = new SPVM::HTTP::Client::Handle;
     if (my $o = $args->get("timeout")) {
       $self->{timeout} = ((SPVM::Double)$o)->val;
@@ -166,15 +177,18 @@ package SPVM::HTTP::Client::Handle {
     }
     my $ks = $headers->keys;
     for (my $i = 0; $i < @$ks; ++$i) {
-      $buf->append_string($ks->[$i] . ":" . (string)($headers->get($ks->[$i])));
+      $buf->append_string($ks->[$i] . ": " . (string)($headers->get($ks->[$i])) . "\r\n");
     }
     $buf->append_string("\r\n");
+    warn("----------------");
+    warn($buf->to_str);
+    warn("----------------");
     $self->write($buf);
   }
 
   sub write_request_header : void ($self : self, $method : string,
       $path_query : string, $headers : SPVM::Hash) {
-    $self->write_header_lines($headers, "$method $path_query\r\n");
+    $self->write_header_lines($headers, "$method $path_query HTTP/1.1\r\n");
   }
 
   sub write_request : void ($self : self, $method : string, $path_query : string,
@@ -190,7 +204,7 @@ package SPVM::HTTP::Client::Handle {
     }
     my $ret = $self->{rbuf}->substr(0, $index + 1)->to_str;
     if ($self->{rbuf}->length == $index + 1) {
-      $self->{rbuf} = undef;
+      $self->{rbuf} = SPVM::StringBuffer->new;
     }
     else {
       $self->{rbuf} = $self->{rbuf}->substr(
@@ -272,7 +286,7 @@ package SPVM::HTTP::Client::Handle {
     for (my $i = 0; $i < $length; ++$i) {
       my $c = $line->[$i];
       if ($c == ':') {
-        my $value = substr($line, $i + 1, index($line, "\n", $i + 1) - $i - 1);
+        my $value = substr($line, $i + 1, index($line, "\r\n", $i + 1) - $i - 1);
         $value = _trim_left($value);
         return [$name, $value];
       }
@@ -345,12 +359,15 @@ package SPVM::HTTP::Client::Handle {
     my $res = 0;
     $string = uc($string);
     for (my $i = 0; $i < $length; ++$i) {
-      my $d = index("0123456789ABCDEF", $string->[$i], 0);
-      if ($i == 0 && $d < 0) {
+      if ('0' <= $string->[$i] && $string->[$i] <= '9') {
+        $res = 16 * $res + $string->[$i] - '0';
+      }
+      elsif ('A' <= $string->[$i] && $string->[$i] <= 'F') {
+        $res = 16 * $res + ($string->[$i] - 'A' + 10);
+      }
+      else {
         die "Length is not hex: '$string'";
       }
-      $res *= 10;
-      $res += $d;
     }
     return $res;
   }
@@ -438,11 +455,23 @@ package SPVM::HTTP::Client::Handle {
     return 1;
   }
 
+  private sub to_int : int ($string : string) {
+    my $length = length $string;
+    my $ret = 0;
+    for (my $i = 0; $i < $length; ++$i) {
+      unless ('0' <= $string->[$i] && $string->[$i] <= '9') {
+        return $ret;
+      }
+      $ret = $ret * 10 + $string->[$i] - '0';
+    }
+    return $ret;
+  }
+
   private sub _read_content_body : int ($self : self,
       $response : SPVM::HTTP::Client::Response, $content_length : SPVM::Int) {
     if (!$content_length) {
       if (my $o = $response->{headers}->get("content-length")) {
-        $content_length = ((SPVM::Int)$o)->val;
+        $content_length = to_int((string)$o);
       }
     }
     if ($content_length) {

--- a/lib/SPVM/HTTP/Client/Response.spvm
+++ b/lib/SPVM/HTTP/Client/Response.spvm
@@ -4,6 +4,8 @@ package SPVM::HTTP::Client::Response {
   has reason : public string;
   has headers : public SPVM::Hash;
   has content : public string;
+  has success : public int;
+  has url : public string;
 
   sub new_with : SPVM::HTTP::Client::Response ($args : SPVM::Hash) {
     my $self = new SPVM::HTTP::Client::Response;
@@ -20,6 +22,8 @@ package SPVM::HTTP::Client::Response {
       $self->{headers} = (SPVM::Hash)$o;
     }
     $self->{content} = "";
+    $self->{success} = 0;
+    $self->{url} = "";
     return $self;
   }
 }

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -26,6 +26,7 @@ package SPVM::StringBuffer {
     my $self = new SPVM::StringBuffer;
     my $default_capacity = 16;
     $self->{value} = new byte [$default_capacity];
+    $self->{length} = 0;
     return $self;
   }
 
@@ -35,6 +36,7 @@ package SPVM::StringBuffer {
       die "capacity must be positive";
     }
     $self->{value} = new byte [$capacity];
+    $self->{length} = 0;
     return $self;
   }
 

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/Client.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/Client.spvm
@@ -4,10 +4,9 @@ package TestCase::Lib::SPVM::HTTP::Client {
 
   sub test_basic : int () {
     my $client = SPVM::HTTP::Client->new;
-    $client->{default_headers} = SPVM::Hash->newa([(object)
-      "X-Foo" => "Bar",
-    ]);
-    $client->request("GET", "http://www.google.com/?q=spvm", undef);
+    $client->{default_headers} = SPVM::Hash->new;
+    $client->request("GET", "http://www.google.com", undef);
+    $client->request("HEAD", "http://www.google.com", undef);
     return 1;
   }
 }


### PR DESCRIPTION
殆どが `GET` の修正で、`HEAD` メソッドなら body を読まないという制御を加えています。