### PR TITLE
JSONのTODO処理, BigIntegerとBigDecimalのValidation修正

### DIFF
--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -8,6 +8,7 @@ package SPVM::JSON {
   use SPVM::Math::BigDecimal;
   use SPVM::Math::BigInteger;
   use SPVM::Math;
+  use SPVM::Sort (sortstr);
 
   has indent : public int;
   has indent_length : public int;
@@ -188,10 +189,10 @@ package SPVM::JSON {
       }
       my $num = sliceb((byte [])$s, $begin, $end_of_digits - $begin);
       if ($is_double) {
-        return SPVM::Math::BigDecimal->new($num);
+        return SPVM::Math::BigDecimal->newstr($num);
       }
       else {
-        return SPVM::Math::BigInteger->new($num);
+        return SPVM::Math::BigInteger->newstr($num);
       }
     }
 
@@ -442,19 +443,6 @@ package SPVM::JSON {
     return (string)$indent_bytes;
   }
 
-  # TODO: Use separated sort function from this module
-  sub _sort_keys : void ($keys : string[]) {
-    for (my $i = 0; $i < @$keys - 1; ++$i) {
-      for (my $j = @$keys - 1; $j > $i; $j--) {
-        if ($keys->[$j - 1] gt $keys->[$j]) {
-          my $temp = $keys->[$j - 1];
-          $keys->[$j - 1] = $keys->[$j];
-          $keys->[$j] = $temp;
-        }
-      }
-    }
-  }
-
   sub _escape_string : string ($string : string) {
     my $length = length $string;
     my $chars = SPVM::List->new;
@@ -520,7 +508,7 @@ package SPVM::JSON {
       my $hash = (SPVM::Hash)$o;
       my $keys = $hash->keys;
       if ($self->{canonical}) {
-        _sort_keys($keys); # TODO: Use separated sort function from this module
+        sortstr($keys);
       }
       for (my $i = 0; $i < @$keys; ++$i) {
         if ($i > 0) {

--- a/lib/SPVM/Math/BigDecimal.spvm
+++ b/lib/SPVM/Math/BigDecimal.spvm
@@ -1,147 +1,207 @@
 package SPVM::Math::BigDecimal {
-  use SPVM::List; # TODO: Replace SPVM::Text
-  use SPVM::Byte;
+  use SPVM::ByteList;
 
   # { digits: "12345", exp: 3 } => "1.2345e3"
-  has digits : private ro string; # leading & trailing 0 are not included.
-  has exp : private ro int;
+  has digits : string; # leading & trailing 0 are not included.
+  has exp : int;
+  has sign : int;
 
-  sub _validate_and_set : void ($self : self, $val : string) {
-    my $length = length $val;
-    unless ($length > 0) {
-      die "val must not be empty";
-    }
-    if ($val->[0] == '.') {
-      die "Cannot start with '.'";
-    }
-    if ($length > 2 && $val->[0] == '0' && $val->[1] != '.') {
-      die "If the first character is '0', the next character must be '.'";
-    }
-    if ($val->[$length - 1] == '.') {
-      die "'.' cannot exist at the end of digits";
-    }
-
-    my $digits = SPVM::List->new;
-    my $dot_pos = -1;
-    my $exp_pos = -1;
-    for (my $i = 0; $i < $length; ++$i) {
-      if ('0' <= $val->[$i] && $val->[$i] <= '9') {
-        $digits->push(SPVM::Byte->new($val->[$i]));
-      }
-      elsif ($val->[$i] == '.' && $dot_pos == -1) {
-        $dot_pos = $i;
-      }
-      elsif (($val->[$i] == 'e' || $val->[$i] == 'E') && $exp_pos == -1) {
-        ++$i;
-        $exp_pos = $i;
-        unless ($i < $length) {
-          die "digits must exist after e/E";
-        }
-        if ($val->[$i] == '+') {
-          ++$i;
-          $exp_pos = $i;
-        }
-        elsif ($val->[$i] == '-') {
-          ++$i;
-        }
-        unless ($i < $length) {
-          die "digits must exist after e/E";
-        }
-        while ($i < $length) {
-          unless ('0' <= $val->[$i] && $val->[$i] <= '9') {
-            die "Not digit or '+'/'-' characters are allowed after 'e'/'E'";
-          }
-          ++$i;
-        }
-        last;
-      }
-      else {
-        die "Invalid decimal: '$val'";
-      }
-    }
-    $self->{exp} = 0;
-    if ($dot_pos >= 0) {
-      $self->{exp} += $dot_pos - 1;
-    }
-    if ($exp_pos >= 0) {
-      my $exp_str = sliceb((byte [])$val, $exp_pos, $length - $exp_pos);
-      $self->{exp} += stoi($exp_str);
-    }
-
-    my $digits_length = $digits->length;
-
-    # remove leading 0
-    for (my $i = 0; $i < $digits_length; ++$i) {
-      if (((SPVM::Byte)($digits->get(0)))->val == '0') {
-        --$self->{exp};
-        $digits->shift;
-      }
-      else {
-        last;
-      }
-    }
-
-    # remove trailing 0
-    $digits_length = $digits->length;
-    for (my $i = 0; $i < $digits_length; ++$i) {
-      if (((SPVM::Byte)($digits->get($digits->length - 1)))->val == '0') {
-        $digits->pop;
-      }
-      else {
-        last;
-      }
-    }
-
-    my $byte_digits = new byte [$digits->length];
-    for (my $i = 0; $i < @$byte_digits; ++$i) {
-      $byte_digits->[$i] = $digits->shift;
-    }
-    $self->{digits} = (string)$byte_digits;
+  private sub _malformed_decimal : void ($string : string) {
+    die "Malformed decimal: $string";
   }
 
-  sub new : SPVM::Math::BigDecimal ($val : string) {
+  private sub _read_digits : void ($val : string, $length : int,
+      $pos : int&, $result : SPVM::ByteList) {
+    for (; $$pos < $length; ++$$pos) {
+      if (isdigit($val->[$$pos])) {
+        $result->push($val->[$$pos]);
+      }
+      else {
+        last;
+      }
+    }
+  }
+
+  private sub _right_trim_zero : SPVM::ByteList ($digits : SPVM::ByteList) {
+    while ($digits->length && $digits->get($digits->length - 1) == '0') {
+      $digits->pop;
+    }
+    return $digits;
+  }
+
+  private sub _read_valid_exponents : void ($self : self, $val : string,
+      $length : int, $pos : int) {
+    my $exp_sign = 1;
+    if ($val->[$pos] == '+') {
+      ++$pos;
+    }
+    elsif ($val->[$pos] == '-') {
+      ++$pos;
+      $exp_sign = -1;
+    }
+    my $exp = SPVM::ByteList->new;
+    _read_digits($val, $length, \$pos, $exp);
+    unless ($pos == $length) {
+      _malformed_decimal($val);
+    }
+    $self->{exp} += $exp_sign * strtoi((string)($exp->to_array), 10);
+  }
+
+  private sub _read_valid_big_decimal : void ($self : self, $val : string) {
+
+    my $length = length $val;
+
+    if ($length == 0) {
+      _malformed_decimal($val);
+    }
+
+    my $pos = 0;
+
+    $self->{sign} = 1;
+
+    if ($val->[0] == '+') {
+      $pos = 1;
+    }
+    elsif ($val->[0] == '-') {
+      $pos = 1;
+      $self->{sign} = -1;
+    }
+
+    # One digit
+    if ($length - $pos == 1) {
+      if (isdigit($val->[0])) {
+        $self->{digits} = $val;
+        $self->{exp} = 0;
+        return;
+      }
+      else {
+        _malformed_decimal($val);
+      }
+    }
+
+    # Double (starts with '0.')
+    # 0.0123 -> ("123", -2)
+    if ($val->[$pos] == '0') {
+      unless ($val->[++$pos] == '.') {
+        _malformed_decimal($val);
+      }
+      ++$pos;
+      my $floating_digits = SPVM::ByteList->new;
+      _read_digits($val, $length, \$pos, $floating_digits);
+
+      $self->{exp} = -1;
+      for (my $i = 0; $floating_digits->length > 0; ++$i) {
+        my $c = $floating_digits->get(0);
+        if ($c == '0') {
+          $floating_digits->shift;
+          --$self->{exp};
+        }
+        else {
+          last;
+        }
+      }
+      if ($floating_digits->length == 0) {
+        $self->{digits} = "0";
+        $self->{exp} = 0;
+        return;
+      }
+
+      _right_trim_zero($floating_digits);
+      $self->{digits} = (string)($floating_digits->to_array);
+
+      # exponents
+      if ($pos < $length) {
+        if ($val->[$pos] == 'e' || $val->[$pos] == 'E') {
+          $self->_read_valid_exponents($val, $length, ++$pos);
+        }
+        else {
+          _malformed_decimal($val);
+        }
+      }
+      return;
+    }
+
+    # Read integer part
+    my $start_digit_pos = $pos;
+    my $digits = SPVM::ByteList->new;
+    _read_digits($val, $length, \$pos, $digits);
+
+    # Integer
+    # 10000 -> ("1", 4)
+    if ($pos == $length) {
+      $self->{digits} = (string)(_right_trim_zero($digits)->to_array);
+      $self->{exp} = $length - 1;
+      return;
+    }
+
+    # Double
+    # 123.45 -> ("12345", 2)
+    if ($val->[$pos] == '.') {
+      ++$pos;
+      if ($pos == $length) {
+        _malformed_decimal($val);
+      }
+      $self->{exp} = $pos - 2 - $start_digit_pos;
+      _read_digits($val, $length, \$pos, $digits);
+      _right_trim_zero($digits);
+
+      # Double (no exponents)
+      if ($pos == $length) {
+        # 10.2300 -> (1.023, 1)
+        $self->{digits} = (string)($digits->to_array);
+        return;
+      }
+    }
+
+    # Double (exponents)
+    if ($val->[$pos] == 'e' || $val->[$pos] == 'E') {
+      $self->{digits} = (string)($digits->to_array);
+      $self->_read_valid_exponents($val, $length, ++$pos);
+    }
+    else {
+      _malformed_decimal($val);
+    }
+  }
+
+  sub new : SPVM::Math::BigDecimal () {
     my $self = new SPVM::Math::BigDecimal;
-    $self->_validate_and_set($val);
+    $self->{digits} = "0";
+    $self->{exp} = 0;
+    return $self;
+  }
+
+  sub newstr : SPVM::Math::BigDecimal ($val : string) {
+    my $self = new SPVM::Math::BigDecimal;
+    $self->_read_valid_big_decimal($val);
     return $self;
   }
 
   sub to_str : string ($self : self) {
-    if ($self->{exp} == 0) {
-      my $digits_length = length($self->{digits});
-      my $ret = new byte [$digits_length + 1];
-      $ret->[0] = $self->{digits}->[0];
-      $ret->[1] = '.';
-      for (my $i = 0; $i < $digits_length - 1; ++$i) {
-        $ret->[$i + 2] = $self->{digits}->[$i + 1];
+
+    my $ret = "";
+
+    if ($self->{sign} < 0) {
+      $ret = "-";
+    }
+
+    my $exp_str = "" . $self->{exp};
+
+    my $digits_length = length $self->{digits};
+
+    if ($digits_length == 1) {
+      $ret .= [$self->{digits}->[0]];
+      if ($self->{exp} != 0) {
+        $ret .= "e$exp_str";
       }
       return $ret;
     }
     else {
-      my $exp_str = "" . $self->{exp};
-      my $digits_length = length($self->{digits});
-      my $exp_length = length($exp_str);
-      if ($digits_length == 1) {
-        my $ret = new byte [$exp_length + 2];
-        $ret->[0] = $self->{digits}->[0];
-        $ret->[1] = 'e';
-        for (my $i = 0; $i < $exp_length; ++$i) {
-          $ret->[$i + 2] = $exp_str->[$i];
-        }
-        return $ret;
+      $ret .= [$self->{digits}->[0], '.'];
+      $ret .= substr($self->{digits}, 1, $digits_length - 1);
+      if ($self->{exp} != 0) {
+        $ret .= "e$exp_str";
       }
-      else {
-        my $ret = new byte [$digits_length + $exp_length + 2];
-        $ret->[0] = $self->{digits}->[0];
-        $ret->[1] = '.';
-        for (my $i = 0; $i < $digits_length - 1; ++$i) {
-          $ret->[$i + 2] = $self->{digits}->[$i + 1];
-        }
-        $ret->[$digits_length + 1] = 'e';
-        for (my $i = 0; $i < $exp_length; ++$i) {
-          $ret->[$i + $digits_length + 2] = $exp_str->[$i];
-        }
-        return $ret;
-      }
+      return $ret;
     }
   }
 

--- a/lib/SPVM/Math/BigInteger.spvm
+++ b/lib/SPVM/Math/BigInteger.spvm
@@ -1,5 +1,5 @@
 package SPVM::Math::BigInteger {
-  has val : private ro string;
+  has val : string;
 
   sub _validate : void ($val : string) {
     my $length = length $val;
@@ -16,7 +16,13 @@ package SPVM::Math::BigInteger {
     }
   }
 
-  sub new : SPVM::Math::BigInteger ($val : string) {
+  sub new : SPVM::Math::BigInteger () {
+    my $self = new SPVM::Math::BigInteger;
+    $self->{val} = "0";
+    return $self;
+  }
+
+  sub newstr : SPVM::Math::BigInteger ($val : string) {
     my $self = new SPVM::Math::BigInteger;
     _validate($val);
     $self->{val} = $val;

--- a/lib/SPVM/Sort.spvm
+++ b/lib/SPVM/Sort.spvm
@@ -65,4 +65,18 @@ package SPVM::Sort {
     my $b = new_oarray_proto($objs, $length);
     _merge_sort($objs, $b, 0, $length - 1, $length, $comparator);
   }
+
+  sub sortstr : void ($strs : string[]) {
+    sorto($strs, sub : int ($self : self, $a : object, $b : object) {
+      if ((string)$a le (string)$b) {
+        return -1;
+      }
+      elsif ((string)$a ge (string)$b) {
+        return +1;
+      }
+      else {
+        return 0;
+      }
+    });
+  }
 }

--- a/lib/SPVM/Sort.spvm
+++ b/lib/SPVM/Sort.spvm
@@ -46,7 +46,7 @@ package SPVM::Sort {
   }
 
   precompile sub _merge_sort : void($a : oarray, $b : oarray, $left : int, $right : int, $n : int, $comparator : SPVM::Comparator){
-      if ($left == $right) {
+      if ($left >= $right) {
         return;
       }
 

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -74,13 +74,7 @@ package SPVM::StringBuffer {
 
   # O($self->{length} + $buffer)
   sub prepend : void ($self : self, $buffer : SPVM::StringBuffer) {
-    
-    # TODO: Think how to deal with capacity.
-    my $capacity = @$self->{value}; # capacity is not shrunk.
-    if ($capacity < $self->{length} + $buffer->{length}) { # don't consider about x2 allocation.
-      $capacity = $self->{length} + $buffer->{length};
-    }
-    my $new_string = new byte [$capacity];
+    my $new_string = new byte [$self->{length} + $buffer->{length}];
     for (my $i = 0; $i < $buffer->{length}; ++$i) {
       $new_string->[$i] = $buffer->{value}->[$i];
     }
@@ -88,7 +82,7 @@ package SPVM::StringBuffer {
       $new_string->[$buffer->{length} + $i] = $self->{value}[$i];
     }
     $self->{value} = $new_string;
-    $self->{length} += $buffer->{length};
+    $self->{length} = @$new_string;
   }
 
   sub append : void ($self : self, $buffer : SPVM::StringBuffer) {

--- a/t/default/lib-SPVM-Math-BigDecimal.t
+++ b/t/default/lib-SPVM-Math-BigDecimal.t
@@ -1,0 +1,22 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::Math::BigDecimal';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::Math::BigDecimal
+{
+  ok(TestCase::Lib::SPVM::Math::BigDecimal->basic());
+}
+
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-Math-BigInteger.t
+++ b/t/default/lib-SPVM-Math-BigInteger.t
@@ -1,0 +1,22 @@
+use lib "t/lib";
+use TestAuto;
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use SPVM 'TestCase::Lib::SPVM::Math::BigInteger';
+
+# Start objects count
+my $start_memory_blocks_count = SPVM::memory_blocks_count();
+
+# SPVM::Math::BigInteger
+{
+  ok(TestCase::Lib::SPVM::Math::BigInteger->basic());
+}
+
+
+# All object is freed
+my $end_memory_blocks_count = SPVM::memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);

--- a/t/default/lib-SPVM-Sort.t
+++ b/t/default/lib-SPVM-Sort.t
@@ -31,8 +31,11 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   # sortd
   ok(TestCase::Lib::SPVM::Sort->test_sortd);
 
-  # sortd
+  # sorto
   ok(TestCase::Lib::SPVM::Sort->test_sorto);
+
+  # sortstr
+  ok(TestCase::Lib::SPVM::Sort->test_sortstr);
 }
 
 # All object is freed

--- a/t/default/lib/TestCase/Lib/SPVM/Math/BigDecimal.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Math/BigDecimal.spvm
@@ -1,0 +1,118 @@
+package TestCase::Lib::SPVM::Math::BigDecimal {
+  use SPVM::Math::BigDecimal;
+
+  sub basic : int () {
+    {
+      # constructor
+      my $expected = "0";
+      my $val = SPVM::Math::BigDecimal->new;
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # integer
+      my $expected = "1";
+      my $val = SPVM::Math::BigDecimal->newstr("1");
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # integer
+      my $expected = "2e100";
+      my $val = SPVM::Math::BigDecimal->newstr("2e100");
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # integer
+      my $expected = "1.000000000000000000000000000001e30";
+      my $val = SPVM::Math::BigDecimal->newstr("1000000000000000000000000000001");
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # signed double (+)
+      my $expected = "1.23e1";
+      my $val = SPVM::Math::BigDecimal->newstr("+12.3");
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # signed double (-)
+      my $expected = "-1.23e1";
+      my $val = SPVM::Math::BigDecimal->newstr("-12.3");
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # signed double (+, e)
+      my $expected = "1.23e4";
+      my $val = SPVM::Math::BigDecimal->newstr("+12.3e+3");
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # signed double (-)
+      my $expected = "-1.23e-2";
+      my $val = SPVM::Math::BigDecimal->newstr("-12.3e-3");
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # 0.xxx
+      my $expected = "1e-6";
+      my $val = SPVM::Math::BigDecimal->newstr("0.000001");
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # big decimal
+      my $expected = "1.00000000000000000000000000000000000000001e20";
+      my $val = SPVM::Math::BigDecimal->newstr("100000000000000000000.000000000000000000001");
+      unless ($val->to_str eq $expected) {
+        warn("expected: '$expected'");
+        warn("actual: '" . $val->to_str . "'");
+        return 0;
+      }
+    }
+    {
+      # invalid value
+      my $str = "10.0.0";
+      eval {
+        my $val = SPVM::Math::BigDecimal->newstr($str);
+      };
+      unless ($@) {
+        return 0;
+      }
+      $@ = undef;
+    }
+    return 1;
+  }
+}

--- a/t/default/lib/TestCase/Lib/SPVM/Math/BigInteger.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Math/BigInteger.spvm
@@ -1,0 +1,33 @@
+package TestCase::Lib::SPVM::Math::BigInteger {
+  use SPVM::Math::BigInteger;
+
+  sub basic : int () {
+    {
+      # constructor
+      my $val = SPVM::Math::BigInteger->new;
+      unless ($val->to_str eq "0") {
+        return 0;
+      }
+    }
+    {
+      # integer
+      my $str = "111111111111111111111111111111111111111111";
+      my $val = SPVM::Math::BigInteger->newstr($str);
+      unless ($val->to_str == $str) {
+        return 0;
+      }
+    }
+    {
+      # invalid value
+      my $str = "1111111111111111111111111111111111111xxx11";
+      eval {
+        my $val = SPVM::Math::BigInteger->newstr($str);
+      };
+      unless ($@) {
+        return 0;
+      }
+      $@ = undef;
+    }
+    return 1;
+  }
+}

--- a/t/default/lib/TestCase/Lib/SPVM/Sort.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Sort.spvm
@@ -1,6 +1,6 @@
 package TestCase::Lib::SPVM::Sort {
   use TestCase::Minimal;
-  use SPVM::Sort(sortb, sorts, sorti, sortl, sortf, sortd, sorto);
+  use SPVM::Sort(sortb, sorts, sorti, sortl, sortf, sortd, sorto, sortstr);
   
   sub test_sortb : int () {
     {
@@ -93,6 +93,16 @@ package TestCase::Lib::SPVM::Sort {
       unless (equals_oarray($ms, [$m11, $m12, $m15, $m10, $m14, $m13])) {
         return 0;
       }
+    }
+    return 1;
+  }
+
+  sub test_sortstr : int () {
+    my $strs = ["aba", "ab", "abc", "a"];
+    my $expected = ["a", "ab", "aba", "abc"];
+    sortstr($strs);
+    unless (equals_strarray($strs, $expected)) {
+      return 0;
     }
     return 1;
   }


### PR DESCRIPTION
See: #102 #103
* `JSON` の TODO 対応
* 上記に伴い以下を修正
  * `BigInteger`, `BigDecimal` の validation 修正
  * merge sort の再帰の終了条件の式を一部修正