### PR TITLE
revert SPVM::HTML::URL::Escape

### DIFF
--- a/lib/SPVM/HTTP/URL/Escape.spvm
+++ b/lib/SPVM/HTTP/URL/Escape.spvm
@@ -1,0 +1,79 @@
+package SPVM::HTTP::URL::Escape {
+
+  private sub HEX_CHARS : string () {
+    return "0123456789ABCDEF";
+  }
+
+  private sub is_unreserved : int ($c : byte) {
+    # RFC3986
+    return ('A' <= $c && $c <= 'Z') ||
+      ('a' <= $c && $c <= 'z') ||
+      ('0' <= $c && $c <= '9') ||
+      $c == '-' ||
+      $c == '.' ||
+      $c == '_' ||
+      $c == '~';
+  }
+
+  private sub is_sub_delim : int ($c : byte) {
+    return $c == '!' || $c == '$' || $c == '&' ||
+      $c == '\'' || $c == '(' || $c == ')' ||
+      $c == '*' || $c == '+' || $c == ',' ||
+      $c == ';' || $c == '=';
+  }
+
+  private sub hex_index : int ($c : byte) {
+    if ('0' <= $c && $c <= '9') {
+      return $c - '0';
+    }
+    elsif ('A' <= $c && $c <= 'F') {
+      return $c - 'A' + 10;
+    }
+    else {
+      die "string is broken. invalid hex-digit. c = '" . [$c] . "'";
+    }
+  }
+
+  sub escape : string ($str : string) {
+    my $res = "";
+    my $length = length $str;
+    for (my $i = 0; $i < $length; ++$i) {
+      my $c : int = $str->[$i] & 0xFF;
+      if (is_unreserved((byte)$c) || is_sub_delim((byte)$c)) {
+        $res .= [(byte)$c];
+      } else {
+        $res .= ['%', HEX_CHARS()->[(int)($c / 16)], HEX_CHARS()->[$c % 16]];
+      }
+    }
+    return $res;
+  }
+
+  sub unescape : string ($str : string) {
+    my $res = "";
+    my $length = length $str;
+    for (my $i = 0; $i < $length; ++$i) {
+      if (is_unreserved($str->[$i]) || is_sub_delim($str->[$i])) {
+        $res .= [$str->[$i]];
+      }
+      else {
+        unless ($str->[$i] == '%') {
+          die "string is broken. '%' is expected. str: $str";
+        }
+        unless ($i + 2 < $length) {
+          die "string is broken. two hex-digits are required after '%'. str: $str";
+        }
+        $res .= [(byte)(hex_index($str->[$i + 1]) * 16 + hex_index($str->[$i + 2]))];
+        $i += 2;
+      }
+    }
+    return $res;
+  }
+}
+
+=pod
+
+=head1 NAME
+
+SPVM::HTTP::URL::Escape - Percent-encode and percent-decode unsafe characters
+
+=cut

--- a/lib/SPVM/HTTP/URL/Parameters.spvm
+++ b/lib/SPVM/HTTP/URL/Parameters.spvm
@@ -1,15 +1,12 @@
 package SPVM::HTTP::URL::Parameters {
   use SPVM::HTTP::URL::Escape;
-  use SPVM::HTTP::URL::Encode;
 
   has params : string[][];
   has size : int;
-  has use_form_encoder : public int;
 
   sub new : SPVM::HTTP::URL::Parameters () {
     my $self = new SPVM::HTTP::URL::Parameters;
     $self->{params} = new string[][16];
-    $self->{use_form_encoder} = 0;
     return $self;
   }
 
@@ -85,11 +82,7 @@ package SPVM::HTTP::URL::Parameters {
         }
         my $key = sliceb((byte [])$str, $start_token, $i - $start_token);
         my $val = sliceb((byte [])$str, $start_val, $end_val - $start_val);
-        if ($self->{use_form_encoder}) {
-          $self->add($key, SPVM::HTTP::URL::Encode->decode($val));
-        } else {
-          $self->add($key, SPVM::HTTP::URL::Escape->unescape($val));
-        }
+        $self->add($key, SPVM::HTTP::URL::Escape->unescape($val));
         $start_token = $end_val + 1; # if $end_val < $length
         $i = $end_val;
       }
@@ -109,13 +102,8 @@ package SPVM::HTTP::URL::Parameters {
         if (length($result)) {
           $result .= "&";
         }
-        if ($self->{use_form_encoder}) {
-          $result .= $keys->[$key_index] . "=" .
-            SPVM::HTTP::URL::Encode->encode($multi_vals->[$val_index]);
-        } else {
-          $result .= $keys->[$key_index] . "=" .
-            SPVM::HTTP::URL::Escape->escape($multi_vals->[$val_index]);
-        }
+        $result .= $keys->[$key_index] . "=" .
+          SPVM::HTTP::URL::Escape->escape($multi_vals->[$val_index]);
       }
     }
     return $result;

--- a/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Parameters.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/HTTP/URL/Parameters.spvm
@@ -15,21 +15,6 @@ package TestCase::Lib::SPVM::HTTP::URL::Parameters {
     return 1;
   }
 
-  sub test_encode : int () {
-    my $params = SPVM::HTTP::URL::Parameters->new;
-    $params->add("foo" => "尾骶骨𠮷 🤔");
-    $params->add("hoge" => "fuga");
-    $params->add("foo" => "piyo");
-    $params->{use_form_encoder} = 1;
-    my $got = $params->to_str();
-    my $expected = "foo=%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7+%F0%9F%A4%94&foo=piyo&hoge=fuga";
-    unless ($got eq $expected) {
-      warn("failed to encode parameters.\n     got: '$got'\nexpected: '$expected'");
-      return 0;
-    }
-    return 1;
-  }
-
   sub test_parse : int () {
     my $params = SPVM::HTTP::URL::Parameters->parse(
         "foo=%E5%B0%BE%E9%AA%B6%E9%AA%A8%F0%A0%AE%B7%F0%9F%A4%94&hoge=fuga&foo=piyo");

--- a/t/default/modules/SPVM-HTTP-URL-Parameters.t
+++ b/t/default/modules/SPVM-HTTP-URL-Parameters.t
@@ -14,7 +14,6 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 # SPVM::HTTP::URL::Parameters
 {
   ok(TestCase::Lib::SPVM::HTTP::URL::Parameters->test_escape);
-  ok(TestCase::Lib::SPVM::HTTP::URL::Parameters->test_encode);
   ok(TestCase::Lib::SPVM::HTTP::URL::Parameters->test_parse);
   ok(TestCase::Lib::SPVM::HTTP::URL::Parameters->test_add_get);
   ok(TestCase::Lib::SPVM::HTTP::URL::Parameters->test_keys);


### PR DESCRIPTION
#121 の対応で一時的に `SPVM::HTTP::URL::Escape` の削除を revert します。後に削除予定です。
また `SPVM::HTTP::URL::Encode` の依存を削除します。