### PR TITLE
SPVM::JSON のリファクタリング

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -134,6 +134,7 @@ sub MY::postamble {
     $make_rule .= SPVM::Builder::Util::create_make_rule_precompile('SPVM::Util');
     $make_rule .= SPVM::Builder::Util::create_make_rule_precompile('SPVM::Regex');
     $make_rule .= SPVM::Builder::Util::create_make_rule_precompile('SPVM::Unicode');
+    $make_rule .= SPVM::Builder::Util::create_make_rule_precompile('SPVM::JSON');
   }
   
   return $make_rule;

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -630,7 +630,7 @@ package SPVM::JSON {
     # Hash
     elsif ($spvm_data isa SPVM::Hash) {
       my $buffer = SPVM::StringBuffer->new;
-      $buffer->push("{");
+      $buffer->push_char('{');
       my $hash = (SPVM::Hash)$spvm_data;
       my $keys = $hash->keys;
       if ($self->canonical) {
@@ -638,33 +638,34 @@ package SPVM::JSON {
       }
       for (my $keys_index = 0; $keys_index < @$keys; ++$keys_index) {
         if ($keys_index > 0) {
-          $buffer->push(",");
+          $buffer->push_char(',');
         }
-        $buffer->push("\"");
+        $buffer->push_char('"');
         $buffer->push($keys->[$keys_index]);
-        $buffer->push("\":");
+        $buffer->push_char('"');
+        $buffer->push_char(':');
         my $json_part = $self->_encode_recursive($hash->get($keys->[$keys_index]), $depth + 1);
         $buffer->push($json_part);
       }
-      $buffer->push("}");
+      $buffer->push_char('}');
       
       $json = $buffer->to_str;
     }
     # Array
     elsif ($spvm_data isa SPVM::ObjectList) {
       my $buffer = SPVM::StringBuffer->new;
-      $buffer->push("[");
+      $buffer->push_char('[');
       
       my $list = (SPVM::ObjectList)$spvm_data;
       my $length = $list->length;
       for (my $list_index = 0; $list_index < $length; ++$list_index) {
         if ($list_index > 0) {
-          $buffer->push(",");
+          $buffer->push_char(',');
         }
         my $json_part = $self->_encode_recursive($list->get($list_index), $depth + 1);
         $buffer->push($json_part);
       }
-      $buffer->push("]");
+      $buffer->push_char(']');
       
       $json = $buffer->to_str;
     }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -21,15 +21,15 @@ package SPVM::JSON {
     LDBL_DIG = 18
   }
 
-  precompile private sub _custom_die : void ($die_message : string, $json_str : string, $start : int) {
-    my $end = length $json_str;
+  precompile private sub _custom_die : void ($die_message : string, $json : string, $start : int) {
+    my $end = length $json;
     my $max_dump_length = 10;
     if ($max_dump_length > $end - $start) {
       $max_dump_length = $end - $start;
     }
     my $hint = "";
     if ($max_dump_length > 0) {
-      $hint = "near '" . substr($json_str, $start, $end - $start) . "'";
+      $hint = "near '" . substr($json, $start, $end - $start) . "'";
     }
     else {
       $hint = "end of string";
@@ -37,28 +37,28 @@ package SPVM::JSON {
     die $die_message . " ... $hint";
   }
 
-  precompile private sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&) {
-    my $end = length $json_str;
+  precompile private sub _skip_spaces : void ($self : self, $json : string, $iter : int&) {
+    my $end = length $json;
     for (; 1 ; ++$$iter) {
       if ($$iter == $end) {
         return;
       }
-      unless ($json_str->[$$iter] == ' ' || $json_str->[$$iter] == '\n' || $json_str->[$$iter] == '\t' || $json_str->[$$iter] == '\r') {
+      unless ($json->[$$iter] == ' ' || $json->[$$iter] == '\n' || $json->[$$iter] == '\t' || $json->[$$iter] == '\r') {
         last;
       }
     }
   }
 
-  precompile private sub _expect_token : void ($json_str : string, $iter : int&, $expected : string) {
-    my $end = length $json_str;
+  precompile private sub _expect_token : void ($json : string, $iter : int&, $expected : string) {
+    my $end = length $json;
     my $length = length $expected;
     unless ($$iter + $length <= $end) {
-      _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter);
+      _custom_die("Expected token: $expected doesn't exist", $json, $$iter);
     }
     my $begin = $$iter;
     while (1) {
-      unless ($json_str->[$$iter] == $expected->[$$iter - $begin]) {
-        _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter);
+      unless ($json->[$$iter] == $expected->[$$iter - $begin]) {
+        _custom_die("Expected token: $expected doesn't exist", $json, $$iter);
       }
       ++$$iter;
       if ($$iter - $begin == $length) {
@@ -67,18 +67,18 @@ package SPVM::JSON {
     }
   }
 
-  precompile private sub _decode_string : string ($self : self, $json_str : string, $iter : int&) {
-    my $end = length $json_str;
+  precompile private sub _decode_string : string ($self : self, $json : string, $iter : int&) {
+    my $end = length $json;
     my $buffer = SPVM::StringBuffer->new;
 
-    _expect_token($json_str, $iter, "\"");
+    _expect_token($json, $iter, "\"");
 
     my $special_char_expected = 0;
     while (1) {
-      if ($$iter >= $end || (!$special_char_expected && $json_str->[$$iter] == '"')) {
+      if ($$iter >= $end || (!$special_char_expected && $json->[$$iter] == '"')) {
         last;
       }
-      my $char = $json_str->[$$iter];
+      my $char = $json->[$$iter];
       if ($special_char_expected) {
         switch ((int)$char) {
           case 34: # '"'
@@ -100,7 +100,7 @@ package SPVM::JSON {
             break;
           }
           default: {
-            _custom_die("Undefined special char", $json_str, $$iter);
+            _custom_die("Undefined special char", $json, $$iter);
           }
         }
         $special_char_expected = 0;
@@ -110,67 +110,67 @@ package SPVM::JSON {
       }
       else {
         if ($char == '\t') {
-          _custom_die("Literal ASCII tab characters are not allowed in string", $json_str, $$iter);
+          _custom_die("Literal ASCII tab characters are not allowed in string", $json, $$iter);
         }
         $buffer->push_char($char);
       }
       ++$$iter;
     }
     if ($$iter == $end) {
-      _custom_die("Invalid string. end-quote doesn't exist", $json_str, $$iter);
+      _custom_die("Invalid string. end-quote doesn't exist", $json, $$iter);
     }
 
-    _expect_token($json_str, $iter, "\"");
+    _expect_token($json, $iter, "\"");
 
     return (string)$buffer->to_str;
   }
 
-  precompile private sub _atof_scan1 : double ($json_str : string, $iter : int,
+  precompile private sub _atof_scan1 : double ($json : string, $iter : int,
       $accum : double&, $expo : int&, $postdp : int, $maxdepth : int) {
-    my $end = length $json_str;
+    my $end = length $json;
     my $long_accum : long = 0;
     my $expo_accum = 0;
 
     # if we recurse too deep, skip all remaining digits
     # to avoid a stack overflow attack
     if (--$maxdepth <= 0) {
-      while ($iter < $end && ($json_str->[$iter] - '0') < 10) {
+      while ($iter < $end && ($json->[$iter] - '0') < 10) {
         ++$iter;
       }
     }
 
     while ($iter < $end) {
-      if ($json_str->[$iter] == '.') {
+      if ($json->[$iter] == '.') {
         ++$iter;
-        _atof_scan1($json_str, $iter, $accum, $expo, 1, $maxdepth);
+        _atof_scan1($json, $iter, $accum, $expo, 1, $maxdepth);
         last;
       }
-      elsif ($json_str->[$iter] == 'e' || $json_str->[$iter] == 'E') {
+      elsif ($json->[$iter] == 'e' || $json->[$iter] == 'E') {
         my $exp2 = 0;
         my $neg = 0;
 
         ++$iter;
 
         if ($iter >= $end) {
-          _custom_die ("malformed number (no digits after e/E)", $json_str, $iter);
+          _custom_die ("malformed number (no digits after e/E)", $json, $iter);
         }
 
-        if ($json_str->[$iter] == '-') {
+        if ($json->[$iter] == '-') {
           ++$iter;
           $neg = 1;
         }
-        elsif ($json_str->[$iter] == '+') {
+        elsif ($json->[$iter] == '+') {
           ++$iter;
         }
 
         if ($iter >= $end) {
-          _custom_die ("malformed number (no digits after e/E)", $json_str, $iter);
+          _custom_die ("malformed number (no digits after e/E)", $json, $iter);
         }
 
         while ($iter < $end) {
-          my $dig = $json_str->[$iter] - '0';
+          my $dig = $json->[$iter] - '0';
           if ($dig < 10) {
-            $exp2 = $exp2 * 10 + $json_str->[$iter++] - '0';
+            $exp2 = $exp2 * 10 + $json->[$iter++] - '0';
           }
           else {
             last;
@@ -185,8 +185,8 @@ package SPVM::JSON {
         }
         last;
       }
-      elsif ($json_str->[$iter] >= '0' && $json_str->[$iter] <= '9') {
-        my $dig = $json_str->[$iter] - '0';
+      elsif ($json->[$iter] >= '0' && $json->[$iter] <= '9') {
+        my $dig = $json->[$iter] - '0';
 
         ++$iter;
 
@@ -199,7 +199,7 @@ package SPVM::JSON {
           if ($postdp) {
             $$expo -= $expo_accum;
           }
-          _atof_scan1($json_str, $iter, $accum, $expo, $postdp, $maxdepth);
+          _atof_scan1($json, $iter, $accum, $expo, $postdp, $maxdepth);
           if ($postdp) {
             $$expo += $expo_accum;
           }
@@ -219,18 +219,18 @@ package SPVM::JSON {
     $$expo += $expo_accum;
   }
 
-  precompile private sub _atof : double ($json_str : string, $start : int) {
+  precompile private sub _atof : double ($json : string, $start : int) {
     my $accum = 0.0;
     my $expo = 0;
     my $neg = 0;
 
-    if ($json_str->[$start] == '-') {
+    if ($json->[$start] == '-') {
       ++$start;
       $neg = 1;
     }
 
     # a recursion depth of ten gives us >>500 bits
-    _atof_scan1($json_str, $start, \$accum, \$expo, 0, 10);
+    _atof_scan1($json, $start, \$accum, \$expo, 0, 10);
 
     if ($neg) {
       return -$accum;
@@ -240,17 +240,17 @@ package SPVM::JSON {
     }
   }
 
-  precompile private sub _grok_non_neg : int ($json_str : string, $start : int, $len : int, $val : long&) {
+  precompile private sub _grok_non_neg : int ($json : string, $start : int, $len : int, $val : long&) {
     my $number_type = 0;
     $$val = 0;
     for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
       if ($$val <= (long)INT32_MAX()) {
-        $$val = $$val * 10 + $json_str->[$start + $digit_index] - '0';
+        $$val = $$val * 10 + $json->[$start + $digit_index] - '0';
       }
       elsif ($$val < INT64_MAX() / 10 ||
-          ($$val == INT64_MAX() / 10 && $json_str->[$start + $digit_index] - '0' <= INT64_MAX() % 10)) {
+          ($$val == INT64_MAX() / 10 && $json->[$start + $digit_index] - '0' <= INT64_MAX() % 10)) {
         $number_type = 1;
-        $$val = $$val * 10 + $json_str->[$start + $digit_index] - '0';
+        $$val = $$val * 10 + $json->[$start + $digit_index] - '0';
       }
       else {
         return -1;
@@ -259,18 +259,18 @@ package SPVM::JSON {
     return $number_type;
   }
 
-  precompile private sub _grok_neg : int ($json_str : string, $start : int, $len : int, $val : long&) {
+  precompile private sub _grok_neg : int ($json : string, $start : int, $len : int, $val : long&) {
     my $number_type = 0;
     $$val = 0;
     for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
       if ($$val >= (long)INT32_MIN()) {
-        $$val = $$val * 10 - ($json_str->[$start + $digit_index] - '0');
+        $$val = $$val * 10 - ($json->[$start + $digit_index] - '0');
       }
       elsif ($$val > INT64_MIN() / 10 ||
           ($$val == INT64_MIN() / 10 &&
-              $json_str->[$start + $digit_index] - '0' <= -(INT64_MIN() + INT64_MIN() / 10 * 10))) {
+              $json->[$start + $digit_index] - '0' <= -(INT64_MIN() + INT64_MIN() / 10 * 10))) {
         $number_type = 1;
-        $$val = $$val * 10 - ($json_str->[$start + $digit_index] - '0');
+        $$val = $$val * 10 - ($json->[$start + $digit_index] - '0');
       }
       else {
         return -1;
@@ -280,17 +280,17 @@ package SPVM::JSON {
   }
 
   # https://metacpan.org/pod/Cpanel::JSON::XS#number
-  precompile private sub _decode_num : object ($self : self, $json_str : string, $iter : int&) {
-    my $end = length $json_str;
-    if ($json_str->[$$iter] == 'n') {
-      if ($$iter + 2 < $end && substr($json_str, $$iter, 3) eq "nan") {
+  precompile private sub _decode_num : object ($self : self, $json : string, $iter : int&) {
+    my $end = length $json;
+    if ($json->[$$iter] == 'n') {
+      if ($$iter + 2 < $end && substr($json, $$iter, 3) eq "nan") {
         $$iter += 3;
       }
-      elsif ($$iter + 3 < $end && substr($json_str, $$iter, 4) eq "null") {
+      elsif ($$iter + 3 < $end && substr($json, $$iter, 4) eq "null") {
         $$iter += 4;
       }
       else {
-        _custom_die("malformed number.", $json_str, $$iter);
+        _custom_die("malformed number.", $json, $$iter);
       }
       return undef;
     }
@@ -299,41 +299,41 @@ package SPVM::JSON {
     my $start = $$iter;
 
     # minus
-    if ($json_str->[$$iter] == '-') {
+    if ($json->[$$iter] == '-') {
       ++$$iter;
     }
 
-    if ($json_str->[$$iter] == 'i') {
-      if ($$iter + 2 < $end && substr($json_str, $$iter, 3) eq "inf") {
+    if ($json->[$$iter] == 'i') {
+      if ($$iter + 2 < $end && substr($json, $$iter, 3) eq "inf") {
         $$iter += 3;
       }
       else {
-        _custom_die("malformed number.", $json_str, $$iter);
+        _custom_die("malformed number.", $json, $$iter);
       }
       return undef;
     }
 
-    if ($json_str->[$$iter] == '0') {
+    if ($json->[$$iter] == '0') {
       ++$$iter;
-      if ($$iter < $end && ($json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9')) {
-        _custom_die("malformed number (leading zero must not be followed by another digit)", $json_str, $$iter);
+      if ($$iter < $end && ($json->[$$iter] >= '0' && $json->[$$iter] <= '9')) {
+        _custom_die("malformed number (leading zero must not be followed by another digit)", $json, $$iter);
       }
     }
-    elsif ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
-      _custom_die ("malformed number (no digits after initial minus)", $json_str, $$iter);
+    elsif ($$iter >= $end || $json->[$$iter] < '0' || $json->[$$iter] > '9') {
+      _custom_die ("malformed number (no digits after initial minus)", $json, $$iter);
     }
 
-    while ($$iter < $end && $json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9') {
+    while ($$iter < $end && $json->[$$iter] >= '0' && $json->[$$iter] <= '9') {
       ++$$iter;
     }
 
     # frac
-    if ($$iter < $end && $json_str->[$$iter] == '.') {
+    if ($$iter < $end && $json->[$$iter] == '.') {
       ++$$iter;
-      if ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
-        _custom_die ("malformed number (no digits after decimal point)", $json_str, $$iter);
+      if ($$iter >= $end || $json->[$$iter] < '0' || $json->[$$iter] > '9') {
+        _custom_die ("malformed number (no digits after decimal point)", $json, $$iter);
       }
-      while ($$iter < $end && $json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9') {
+      while ($$iter < $end && $json->[$$iter] >= '0' && $json->[$$iter] <= '9') {
         ++$$iter;
       }
 
@@ -341,18 +341,18 @@ package SPVM::JSON {
     }
 
     # exp
-    if ($$iter < $end && ($json_str->[$$iter] == 'e' || $json_str->[$$iter] == 'E')) {
+    if ($$iter < $end && ($json->[$$iter] == 'e' || $json->[$$iter] == 'E')) {
       ++$$iter;
 
-      if ($$iter < $end && ($json_str->[$$iter] == '-' || $json_str->[$$iter] == '+')) {
+      if ($$iter < $end && ($json->[$$iter] == '-' || $json->[$$iter] == '+')) {
         ++$$iter;
       }
 
-      if ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
-        _custom_die ("malformed number (no digits after exp sign)", $json_str, $$iter);
+      if ($$iter >= $end || $json->[$$iter] < '0' || $json->[$$iter] > '9') {
+        _custom_die ("malformed number (no digits after exp sign)", $json, $$iter);
       }
 
-      while ($$iter < $end && ($json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9')) {
+      while ($$iter < $end && ($json->[$$iter] >= '0' && $json->[$$iter] <= '9')) {
         ++$$iter;
       }
 
@@ -362,26 +362,26 @@ package SPVM::JSON {
     if (!$is_double) {
       my $len = $$iter - $start;
 
-      if ($json_str->[$start] == '-') {
+      if ($json->[$start] == '-') {
         switch ($len) {
           case 2: {
-            return -(                                                                                                      $json_str->[$start + 1] - '0' *     1);
+            return -(                                                                                                      $json->[$start + 1] - '0' *     1);
             break;
           }
           case 3: {
-            return -(                                                                              $json_str->[$start + 1] * 10 + $json_str->[$start + 2] - '0' *    11);
+            return -(                                                                              $json->[$start + 1] * 10 + $json->[$start + 2] - '0' *    11);
             break;
           }
           case 4: {
-            return -(                                                     $json_str->[$start + 1] * 100 + $json_str->[$start + 2] * 10 + $json_str->[$start + 3] - '0' *   111);
+            return -(                                                     $json->[$start + 1] * 100 + $json->[$start + 2] * 10 + $json->[$start + 3] - '0' *   111);
             break;
           }
           case 5: {
-            return -(                           $json_str->[$start + 1] * 1000 + $json_str->[$start + 2] * 100 + $json_str->[$start + 3] * 10 + $json_str->[$start + 4] - '0' *  1111);
+            return -(                           $json->[$start + 1] * 1000 + $json->[$start + 2] * 100 + $json->[$start + 3] * 10 + $json->[$start + 4] - '0' *  1111);
             break;
           }
           case 6: {
-            return -($json_str->[$start + 1] * 10000 + $json_str->[$start + 2] * 1000 + $json_str->[$start + 3] * 100 + $json_str->[$start + 4] * 10 + $json_str->[$start + 5] - '0' * 11111);
+            return -($json->[$start + 1] * 10000 + $json->[$start + 2] * 1000 + $json->[$start + 3] * 100 + $json->[$start + 4] * 10 + $json->[$start + 5] - '0' * 11111);
             break;
           }
         }
@@ -389,23 +389,23 @@ package SPVM::JSON {
       else {
         switch ($len) {
           case 1: {
-            return (                                                                                                           $json_str->[$start] - '0' *     1);
+            return (                                                                                                           $json->[$start] - '0' *     1);
             break;
           }
           case 2: {
-            return (                                                                                   $json_str->[$start] * 10 + $json_str->[$start + 1] - '0' *    11);
+            return (                                                                                   $json->[$start] * 10 + $json->[$start + 1] - '0' *    11);
             break;
           }
           case 3: {
-            return (                                                          $json_str->[$start] * 100 + $json_str->[$start + 1] * 10 + $json_str->[$start + 2] - '0' *   111);
+            return (                                                          $json->[$start] * 100 + $json->[$start + 1] * 10 + $json->[$start + 2] - '0' *   111);
             break;
           }
           case 4: {
-            return (                                $json_str->[$start] * 1000 + $json_str->[$start + 1] * 100 + $json_str->[$start + 2] * 10 + $json_str->[$start + 3] - '0' *  1111);
+            return (                                $json->[$start] * 1000 + $json->[$start + 1] * 100 + $json->[$start + 2] * 10 + $json->[$start + 3] - '0' *  1111);
             break;
           }
           case 5: {
-            return (     $json_str->[$start] * 10000 + $json_str->[$start + 1] * 1000 + $json_str->[$start + 2] * 100 + $json_str->[$start + 3] * 10 + $json_str->[$start + 4] - '0' * 11111);
+            return (     $json->[$start] * 10000 + $json->[$start + 1] * 1000 + $json->[$start + 2] * 100 + $json->[$start + 3] * 10 + $json->[$start + 4] - '0' * 11111);
             break;
           }
         }
@@ -414,8 +414,8 @@ package SPVM::JSON {
       my $val : long;
       my $number_type = 0;
 
-      if ($json_str->[$start] == '-') {
-        $number_type = _grok_neg($json_str, $start + 1, $len - 1, \$val);
+      if ($json->[$start] == '-') {
+        $number_type = _grok_neg($json, $start + 1, $len - 1, \$val);
         if ($number_type == 0) {
           return (int)$val;
         }
@@ -424,7 +424,7 @@ package SPVM::JSON {
         }
       }
       else {
-        $number_type = _grok_non_neg($json_str, $start, $len, \$val);
+        $number_type = _grok_non_neg($json, $start, $len, \$val);
         if ($number_type == 0) {
           return (int)$val;
         }
@@ -433,150 +433,150 @@ package SPVM::JSON {
         }
       }
 
-      if ($json_str->[$start] == '-') {
+      if ($json->[$start] == '-') {
         --$len;
       }
 
       # does not fit into long, try double
       if (DBL_DIG() >= $len) {
-        return _atof($json_str, $start);
+        return _atof($json, $start);
       }
 
       # everything else fails, convert it to a string
-      return substr($json_str, $start, $$iter - $start);
+      return substr($json, $start, $$iter - $start);
     }
 
     # loss of precision here
-    return _atof($json_str, $start);
+    return _atof($json, $start);
   }
 
-  precompile private sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&) {
-    _expect_token($json_str, $iter, "true");
+  precompile private sub _decode_true : SPVM::JSON::Bool ($self : self, $json : string, $iter : int&) {
+    _expect_token($json, $iter, "true");
     return SPVM::JSON::Bool->TRUE;
   }
 
-  precompile private sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&) {
-    _expect_token($json_str, $iter, "false");
+  precompile private sub _decode_false : SPVM::JSON::Bool ($self : self, $json : string, $iter : int&) {
+    _expect_token($json, $iter, "false");
     return SPVM::JSON::Bool->FALSE;
   }
 
-  precompile private sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $iter : int&) {
-    my $end = length $json_str;
+  precompile private sub _decode_hash : SPVM::Hash ($self : self, $json : string, $iter : int&) {
+    my $end = length $json;
     my $hash = SPVM::Hash->new;
     my $has_element = 0;
 
-    _expect_token($json_str, $iter, "{");
+    _expect_token($json, $iter, "{");
 
     while (1) {
-      $self->_skip_spaces($json_str, $iter);
+      $self->_skip_spaces($json, $iter);
       if ($$iter == $end) {
-        _custom_die("Incomplete object in JSON: end of string", $json_str, $$iter);
+        _custom_die("Incomplete object in JSON: end of string", $json, $$iter);
       }
 
       # end of hash
-      if ($json_str->[$$iter] == '}') {
+      if ($json->[$$iter] == '}') {
         last;
       }
 
       # comma
       if ($has_element) {
-        _expect_token($json_str, $iter, ",");
-        $self->_skip_spaces($json_str, $iter);
+        _expect_token($json, $iter, ",");
+        $self->_skip_spaces($json, $iter);
       }
       else {
         $has_element = 1;
       }
 
       # key
-      my $key = $self->_decode_string($json_str, $iter);
+      my $key = $self->_decode_string($json, $iter);
 
       # separator
-      $self->_skip_spaces($json_str, $iter);
-      _expect_token($json_str, $iter, ":");
+      $self->_skip_spaces($json, $iter);
+      _expect_token($json, $iter, ":");
 
       # value
-      $self->_skip_spaces($json_str, $iter);
-      $hash->set($key, $self->_decode_recursive($json_str, $iter));
+      $self->_skip_spaces($json, $iter);
+      $hash->set($key, $self->_decode_recursive($json, $iter));
     }
 
-    _expect_token($json_str, $iter, "}");
+    _expect_token($json, $iter, "}");
 
     return $hash;
   }
 
-  precompile private sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $iter : int&) {
-    my $end = length $json_str;
+  precompile private sub _decode_list : SPVM::ObjectList ($self : self, $json : string, $iter : int&) {
+    my $end = length $json;
     my $list = SPVM::ObjectList->new;
     my $has_element = 0;
 
-    _expect_token($json_str, $iter, "[");
+    _expect_token($json, $iter, "[");
 
     while (1) {
-      $self->_skip_spaces($json_str, $iter);
+      $self->_skip_spaces($json, $iter);
       if ($$iter == $end) {
-        _custom_die("Incomplete array in JSON: end of string", $json_str, $$iter);
+        _custom_die("Incomplete array in JSON: end of string", $json, $$iter);
       }
 
       # end of list
-      if ($json_str->[$$iter] == ']') {
+      if ($json->[$$iter] == ']') {
         last;
       }
 
       # comma
       if ($has_element) {
-        _expect_token($json_str, $iter, ",");
-        $self->_skip_spaces($json_str, $iter);
+        _expect_token($json, $iter, ",");
+        $self->_skip_spaces($json, $iter);
       }
       else {
         $has_element = 1;
       }
-      $list->push($self->_decode_recursive($json_str, $iter));
+      $list->push($self->_decode_recursive($json, $iter));
     }
 
-    _expect_token($json_str, $iter, "]");
+    _expect_token($json, $iter, "]");
 
     return $list;
   }
 
-  precompile private sub _decode_recursive : object ($self : self, $json_str : string, $iter : int&) {
-    my $end = length $json_str;
+  precompile private sub _decode_recursive : object ($self : self, $json : string, $iter : int&) {
+    my $end = length $json;
 
-    $self->_skip_spaces($json_str, $iter);
+    $self->_skip_spaces($json, $iter);
     if ($$iter == $end) {
-      _custom_die("Incomplete JSON", $json_str, $$iter);
+      _custom_die("Incomplete JSON", $json, $$iter);
     }
 
-    my $c = (int)($json_str->[$$iter]);
+    my $c = (int)($json->[$$iter]);
     switch ($c) {
       case '{': {
         # objects
-        return $self->_decode_hash($json_str, $iter);
+        return $self->_decode_hash($json, $iter);
         break;
       }
       case '[': {
-        return $self->_decode_list($json_str, $iter);
+        return $self->_decode_list($json, $iter);
         break;
       }
       case '"': {
-        return $self->_decode_string($json_str, $iter);
+        return $self->_decode_string($json, $iter);
         break;
       }
       case '-': case 'i': case 'n':
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
-        return $self->_decode_num($json_str, $iter);
+        return $self->_decode_num($json, $iter);
         break;
       }
       case 't': {
-        return $self->_decode_true($json_str, $iter);
+        return $self->_decode_true($json, $iter);
         break;
       }
       case 'f': {
-        return $self->_decode_false($json_str, $iter);
+        return $self->_decode_false($json, $iter);
         break;
       }
       default: {
-        _custom_die("Unexpected token.", $json_str, $$iter);
+        _custom_die("Unexpected token.", $json, $$iter);
       }
     }
   }
@@ -724,17 +724,17 @@ package SPVM::JSON {
     return $self->_encode_recursive($object, 0);
   }
 
-  precompile sub decode : object ($self : self, $json_text : string) {
-    my $length = length $json_text;
+  precompile sub decode : object ($self : self, $json : string) {
+    my $length = length $json;
     my $iter = 0;
-    $self->_skip_spaces($json_text, \$iter);
+    $self->_skip_spaces($json, \$iter);
     if ($iter == $length) {
       return undef;
     }
-    my $ret = $self->_decode_recursive($json_text, \$iter);
-    $self->_skip_spaces($json_text, \$iter);
+    my $ret = $self->_decode_recursive($json, \$iter);
+    $self->_skip_spaces($json, \$iter);
     unless ($iter == $length) {
-      _custom_die("Not all json_text is decoded yet", $json_text, $iter);
+      _custom_die("Not all json_text is decoded yet", $json, $iter);
     }
     return $ret;
   }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -66,7 +66,9 @@ package SPVM::JSON {
 
   precompile private sub _decode_string : string ($self : self, $json_str : string, $iter : int&, $end : int) {
     my $buffer = SPVM::StringBuffer->new;
+
     _expect_token($json_str, $iter, $end, "\"");
+
     my $special_char_expected = 0;
     while (1) {
       if ($$iter >= $end || (!$special_char_expected && $json_str->[$$iter] == '"')) {
@@ -113,7 +115,9 @@ package SPVM::JSON {
     if ($$iter == $end) {
       _custom_die("Invalid string. end-quote doesn't exist", $json_str, $$iter, $end);
     }
+
     _expect_token($json_str, $iter, $end, "\"");
+
     return (string)$buffer->to_str;
   }
 
@@ -453,7 +457,9 @@ package SPVM::JSON {
   precompile private sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $iter : int&, $end : int) {
     my $hash = SPVM::Hash->new;
     my $has_element = 0;
+
     _expect_token($json_str, $iter, $end, "{");
+
     while (1) {
       $self->_skip_spaces($json_str, $iter, $end);
       if ($$iter == $end) {
@@ -485,14 +491,18 @@ package SPVM::JSON {
       $self->_skip_spaces($json_str, $iter, $end);
       $hash->set($key, $self->_decode_recursive($json_str, $iter, $end));
     }
+
     _expect_token($json_str, $iter, $end, "}");
+
     return $hash;
   }
 
   precompile private sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $iter : int&, $end : int) {
-    _expect_token($json_str, $iter, $end, "[");
     my $list = SPVM::ObjectList->new;
     my $has_element = 0;
+
+    _expect_token($json_str, $iter, $end, "[");
+
     while (1) {
       $self->_skip_spaces($json_str, $iter, $end);
       if ($$iter == $end) {
@@ -514,7 +524,9 @@ package SPVM::JSON {
       }
       $list->push($self->_decode_recursive($json_str, $iter, $end));
     }
+
     _expect_token($json_str, $iter, $end, "]");
+
     return $list;
   }
 

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -22,11 +22,15 @@ package SPVM::JSON {
   }
 
   sub ERR : void ($die_message : string, $json_str : string, $start : int, $end : int) {
+    my $max_dump_length = 10;
+    if ($max_dump_length > $end - $start) {
+      $max_dump_length = $end - $start;
+    }
     my $remains = "";
-    if ($end - $start >= 0) {
+    if ($max_dump_length >= 0) {
       $remains = substr($json_str, $start, $end - $start);
     }
-    die $die_message . "\nRemains... '$remains'";
+    die $die_message . " near: '$remains'";
   }
 
   sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&, $end : int) {

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -21,7 +21,7 @@ package SPVM::JSON {
     LDBL_DIG = 18
   }
 
-  private sub _custom_die : void ($die_message : string, $json_str : string, $start : int, $end : int) {
+  precompile private sub _custom_die : void ($die_message : string, $json_str : string, $start : int, $end : int) {
     my $max_dump_length = 10;
     if ($max_dump_length > $end - $start) {
       $max_dump_length = $end - $start;
@@ -33,7 +33,7 @@ package SPVM::JSON {
     die $die_message . " near: '$remains'";
   }
 
-  private sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&, $end : int) {
     for (; 1 ; ++$$iter) {
       if ($$iter == $end) {
         return;
@@ -44,14 +44,14 @@ package SPVM::JSON {
     }
   }
 
-  private sub _skip_spaces_at_not_end : void ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _skip_spaces_at_not_end : void ($self : self, $json_str : string, $iter : int&, $end : int) {
     $self->_skip_spaces($json_str, $iter, $end);
     if ($$iter == $end) {
       _custom_die("Incomplete JSON", $json_str, $$iter, $end);
     }
   }
 
-  private sub _expect_token : void ($json_str : string, $iter : int&, $end : int, $expected : string) {
+  precompile private sub _expect_token : void ($json_str : string, $iter : int&, $end : int, $expected : string) {
     my $length = length $expected;
     unless ($$iter + $length <= $end) {
       _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
@@ -68,7 +68,7 @@ package SPVM::JSON {
     }
   }
 
-  private sub _decode_string : string ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_string : string ($self : self, $json_str : string, $iter : int&, $end : int) {
     my $chars = SPVM::ObjectList->new;
     _expect_token($json_str, $iter, $end, "\"");
     my $special_char_expected = 0;
@@ -127,7 +127,7 @@ package SPVM::JSON {
     return (string)$value;
   }
 
-  private sub _atof_scan1 : double ($json_str : string, $iter : int, $end : int,
+  precompile private sub _atof_scan1 : double ($json_str : string, $iter : int, $end : int,
       $accum : double&, $expo : int&, $postdp : int, $maxdepth : int) {
     my $long_accum : long = 0;
     my $expo_accum = 0;
@@ -220,7 +220,7 @@ package SPVM::JSON {
     $$expo += $expo_accum;
   }
 
-  private sub _atof : double ($json_str : string, $start : int, $end : int) {
+  precompile private sub _atof : double ($json_str : string, $start : int, $end : int) {
     my $accum = 0.0;
     my $expo = 0;
     my $neg = 0;
@@ -241,7 +241,7 @@ package SPVM::JSON {
     }
   }
 
-  private sub _grok_non_neg : int ($json_str : string, $start : int, $len : int, $val : long&) {
+  precompile private sub _grok_non_neg : int ($json_str : string, $start : int, $len : int, $val : long&) {
     my $number_type = 0;
     $$val = 0;
     for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
@@ -260,7 +260,7 @@ package SPVM::JSON {
     return $number_type;
   }
 
-  private sub _grok_neg : int ($json_str : string, $start : int, $len : int, $val : long&) {
+  precompile private sub _grok_neg : int ($json_str : string, $start : int, $len : int, $val : long&) {
     my $number_type = 0;
     $$val = 0;
     for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
@@ -281,7 +281,7 @@ package SPVM::JSON {
   }
 
   # https://metacpan.org/pod/Cpanel::JSON::XS#number
-  private sub _decode_num : object ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_num : object ($self : self, $json_str : string, $iter : int&, $end : int) {
     if ($json_str->[$$iter] == 'n') {
       if ($$iter + 2 < $end && substr($json_str, $$iter, 3) eq "nan") {
         $$iter += 3;
@@ -450,17 +450,17 @@ package SPVM::JSON {
     return _atof($json_str, $start, $end);
   }
 
-  private sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
     _expect_token($json_str, $iter, $end, "true");
     return SPVM::JSON::Bool->TRUE;
   }
 
-  private sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
     _expect_token($json_str, $iter, $end, "false");
     return SPVM::JSON::Bool->FALSE;
   }
 
-  private sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $iter : int&, $end : int) {
     my $hash = SPVM::Hash->new;
     my $has_element = 0;
     _expect_token($json_str, $iter, $end, "{");
@@ -495,7 +495,7 @@ package SPVM::JSON {
     return $hash;
   }
 
-  private sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $iter : int&, $end : int) {
     _expect_token($json_str, $iter, $end, "[");
     my $list = SPVM::ObjectList->new;
     my $has_element = 0;
@@ -520,7 +520,7 @@ package SPVM::JSON {
     return $list;
   }
 
-  private sub _decode_recursive : object ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_recursive : object ($self : self, $json_str : string, $iter : int&, $end : int) {
     $self->_skip_spaces_at_not_end($json_str, $iter, $end);
     my $c = (int)($json_str->[$$iter]);
     switch ($c) {
@@ -557,7 +557,7 @@ package SPVM::JSON {
     }
   }
 
-  private sub _escape_string : string ($string : string) {
+  precompile private sub _escape_string : string ($string : string) {
     my $length = length $string;
     my $chars = SPVM::ObjectList->new;
     for (my $str_index = 0; $str_index < $length; ++$str_index) {
@@ -603,7 +603,7 @@ package SPVM::JSON {
     return (string)$escaped;
   }
 
-  private sub _encode_recursive : string ($self : self, $spvm_data : object, $depth : int) {
+  precompile private sub _encode_recursive : string ($self : self, $spvm_data : object, $depth : int) {
     
     my $json : string;
     
@@ -697,16 +697,16 @@ package SPVM::JSON {
     return $json;
   }
 
-  sub new : SPVM::JSON () {
+  precompile sub new : SPVM::JSON () {
     my $json = new SPVM::JSON;
     return $json;
   }
 
-  sub encode : string ($self : self, $object : object) {
+  precompile sub encode : string ($self : self, $object : object) {
     return $self->_encode_recursive($object, 0);
   }
 
-  sub decode : object ($self : self, $json_text : string) {
+  precompile sub decode : object ($self : self, $json_text : string) {
     my $length = length $json_text;
     my $iter = 0;
     $self->_skip_spaces($json_text, \$iter, $length);

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -495,7 +495,6 @@ package SPVM::JSON {
       _expect_token($json, $iter, ":");
 
       # value
-      $self->_skip_spaces($json, $iter);
       $hash->set($key, $self->_decode_recursive($json, $iter));
     }
 
@@ -525,7 +524,6 @@ package SPVM::JSON {
       # comma
       if ($has_element) {
         _expect_token($json, $iter, ",");
-        $self->_skip_spaces($json, $iter);
       }
       else {
         $has_element = 1;

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -365,48 +365,38 @@ package SPVM::JSON {
       if ($json->[$start] == '-') {
         switch ($len) {
           case 2: {
-            return -(                                                                                                      $json->[$start + 1] - '0' *     1);
-            break;
+            return -(                                                                                                                  $json->[$start + 1] - '0' *     1);
           }
           case 3: {
-            return -(                                                                              $json->[$start + 1] * 10 + $json->[$start + 2] - '0' *    11);
-            break;
+            return -(                                                                                       $json->[$start + 1] * 10 + $json->[$start + 2] - '0' *    11);
           }
           case 4: {
-            return -(                                                     $json->[$start + 1] * 100 + $json->[$start + 2] * 10 + $json->[$start + 3] - '0' *   111);
-            break;
+            return -(                                                           $json->[$start + 1] * 100 + $json->[$start + 2] * 10 + $json->[$start + 3] - '0' *   111);
           }
           case 5: {
-            return -(                           $json->[$start + 1] * 1000 + $json->[$start + 2] * 100 + $json->[$start + 3] * 10 + $json->[$start + 4] - '0' *  1111);
-            break;
+            return -(                              $json->[$start + 1] * 1000 + $json->[$start + 2] * 100 + $json->[$start + 3] * 10 + $json->[$start + 4] - '0' *  1111);
           }
           case 6: {
             return -($json->[$start + 1] * 10000 + $json->[$start + 2] * 1000 + $json->[$start + 3] * 100 + $json->[$start + 4] * 10 + $json->[$start + 5] - '0' * 11111);
-            break;
           }
         }
       }
       else {
         switch ($len) {
           case 1: {
-            return (                                                                                                           $json->[$start] - '0' *     1);
-            break;
+            return (                                                                                                                       $json->[$start] - '0' *     1);
           }
           case 2: {
-            return (                                                                                   $json->[$start] * 10 + $json->[$start + 1] - '0' *    11);
-            break;
+            return (                                                                                            $json->[$start] * 10 + $json->[$start + 1] - '0' *    11);
           }
           case 3: {
-            return (                                                          $json->[$start] * 100 + $json->[$start + 1] * 10 + $json->[$start + 2] - '0' *   111);
-            break;
+            return (                                                                $json->[$start] * 100 + $json->[$start + 1] * 10 + $json->[$start + 2] - '0' *   111);
           }
           case 4: {
-            return (                                $json->[$start] * 1000 + $json->[$start + 1] * 100 + $json->[$start + 2] * 10 + $json->[$start + 3] - '0' *  1111);
-            break;
+            return (                                   $json->[$start] * 1000 + $json->[$start + 1] * 100 + $json->[$start + 2] * 10 + $json->[$start + 3] - '0' *  1111);
           }
           case 5: {
             return (     $json->[$start] * 10000 + $json->[$start + 1] * 1000 + $json->[$start + 2] * 100 + $json->[$start + 3] * 10 + $json->[$start + 4] - '0' * 11111);
-            break;
           }
         }
       }
@@ -549,29 +539,23 @@ package SPVM::JSON {
       case '{': {
         # objects
         return $self->_decode_hash($json, $iter);
-        break;
       }
       case '[': {
         return $self->_decode_list($json, $iter);
-        break;
       }
       case '"': {
         return $self->_decode_string($json, $iter);
-        break;
       }
       case '-': case 'i': case 'n':
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
         return $self->_decode_num($json, $iter);
-        break;
       }
       case 't': {
         return $self->_decode_true($json, $iter);
-        break;
       }
       case 'f': {
         return $self->_decode_false($json, $iter);
-        break;
       }
       default: {
         _custom_die("Unexpected token.", $json, $$iter);

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -26,11 +26,14 @@ package SPVM::JSON {
     if ($max_dump_length > $end - $start) {
       $max_dump_length = $end - $start;
     }
-    my $remains = "";
-    if ($max_dump_length >= 0) {
-      $remains = substr($json_str, $start, $end - $start);
+    my $hint = "";
+    if ($max_dump_length > 0) {
+      $hint = "near '" . substr($json_str, $start, $end - $start) . "'";
     }
-    die $die_message . " near: '$remains'";
+    else {
+      $hint = "end of string";
+    }
+    die $die_message . " ... $hint";
   }
 
   precompile private sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&, $end : int) {

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -723,17 +723,15 @@ package SPVM::JSON {
   }
 
   precompile sub decode : object ($self : self, $json : string) {
-    my $length = length $json;
     my $iter = 0;
+    my $spvm_data = $self->_decode_recursive($json, \$iter);
+
     $self->_skip_spaces($json, \$iter);
-    if ($iter == $length) {
-      return undef;
-    }
-    my $ret = $self->_decode_recursive($json, \$iter);
-    $self->_skip_spaces($json, \$iter);
+    my $length = length $json;
     unless ($iter == $length) {
       _custom_die("Not all json_text is decoded yet", $json, $iter);
     }
-    return $ret;
+
+    return $spvm_data;
   }
 }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -21,7 +21,8 @@ package SPVM::JSON {
     LDBL_DIG = 18
   }
 
-  precompile private sub _custom_die : void ($die_message : string, $json_str : string, $start : int, $end : int) {
+  precompile private sub _custom_die : void ($die_message : string, $json_str : string, $start : int) {
+    my $end = length $json_str;
     my $max_dump_length = 10;
     if ($max_dump_length > $end - $start) {
       $max_dump_length = $end - $start;
@@ -36,7 +37,8 @@ package SPVM::JSON {
     die $die_message . " ... $hint";
   }
 
-  precompile private sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&) {
+    my $end = length $json_str;
     for (; 1 ; ++$$iter) {
       if ($$iter == $end) {
         return;
@@ -47,15 +49,16 @@ package SPVM::JSON {
     }
   }
 
-  precompile private sub _expect_token : void ($json_str : string, $iter : int&, $end : int, $expected : string) {
+  precompile private sub _expect_token : void ($json_str : string, $iter : int&, $expected : string) {
+    my $end = length $json_str;
     my $length = length $expected;
     unless ($$iter + $length <= $end) {
-      _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
+      _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter);
     }
     my $begin = $$iter;
     while (1) {
       unless ($json_str->[$$iter] == $expected->[$$iter - $begin]) {
-        _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
+        _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter);
       }
       ++$$iter;
       if ($$iter - $begin == $length) {
@@ -64,10 +67,11 @@ package SPVM::JSON {
     }
   }
 
-  precompile private sub _decode_string : string ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_string : string ($self : self, $json_str : string, $iter : int&) {
+    my $end = length $json_str;
     my $buffer = SPVM::StringBuffer->new;
 
-    _expect_token($json_str, $iter, $end, "\"");
+    _expect_token($json_str, $iter, "\"");
 
     my $special_char_expected = 0;
     while (1) {
@@ -96,7 +100,7 @@ package SPVM::JSON {
             break;
           }
           default: {
-            _custom_die("Undefined special char", $json_str, $$iter, $end);
+            _custom_die("Undefined special char", $json_str, $$iter);
           }
         }
         $special_char_expected = 0;
@@ -106,23 +110,24 @@ package SPVM::JSON {
       }
       else {
         if ($char == '\t') {
-          _custom_die("Literal ASCII tab characters are not allowed in string", $json_str, $$iter, $end);
+          _custom_die("Literal ASCII tab characters are not allowed in string", $json_str, $$iter);
         }
         $buffer->push_char($char);
       }
       ++$$iter;
     }
     if ($$iter == $end) {
-      _custom_die("Invalid string. end-quote doesn't exist", $json_str, $$iter, $end);
+      _custom_die("Invalid string. end-quote doesn't exist", $json_str, $$iter);
     }
 
-    _expect_token($json_str, $iter, $end, "\"");
+    _expect_token($json_str, $iter, "\"");
 
     return (string)$buffer->to_str;
   }
 
-  precompile private sub _atof_scan1 : double ($json_str : string, $iter : int, $end : int,
+  precompile private sub _atof_scan1 : double ($json_str : string, $iter : int,
       $accum : double&, $expo : int&, $postdp : int, $maxdepth : int) {
+    my $end = length $json_str;
     my $long_accum : long = 0;
     my $expo_accum = 0;
 
@@ -137,7 +142,7 @@ package SPVM::JSON {
     while ($iter < $end) {
       if ($json_str->[$iter] == '.') {
         ++$iter;
-        _atof_scan1($json_str, $iter, $end, $accum, $expo, 1, $maxdepth);
+        _atof_scan1($json_str, $iter, $accum, $expo, 1, $maxdepth);
         last;
       }
       elsif ($json_str->[$iter] == 'e' || $json_str->[$iter] == 'E') {
@@ -147,7 +152,7 @@ package SPVM::JSON {
         ++$iter;
 
         if ($iter >= $end) {
-          _custom_die ("malformed number (no digits after e/E)", $json_str, $iter, $end);
+          _custom_die ("malformed number (no digits after e/E)", $json_str, $iter);
         }
 
         if ($json_str->[$iter] == '-') {
@@ -159,7 +164,7 @@ package SPVM::JSON {
         }
 
         if ($iter >= $end) {
-          _custom_die ("malformed number (no digits after e/E)", $json_str, $iter, $end);
+          _custom_die ("malformed number (no digits after e/E)", $json_str, $iter);
         }
 
         while ($iter < $end) {
@@ -194,7 +199,7 @@ package SPVM::JSON {
           if ($postdp) {
             $$expo -= $expo_accum;
           }
-          _atof_scan1($json_str, $iter, $end, $accum, $expo, $postdp, $maxdepth);
+          _atof_scan1($json_str, $iter, $accum, $expo, $postdp, $maxdepth);
           if ($postdp) {
             $$expo += $expo_accum;
           }
@@ -214,7 +219,7 @@ package SPVM::JSON {
     $$expo += $expo_accum;
   }
 
-  precompile private sub _atof : double ($json_str : string, $start : int, $end : int) {
+  precompile private sub _atof : double ($json_str : string, $start : int) {
     my $accum = 0.0;
     my $expo = 0;
     my $neg = 0;
@@ -225,7 +230,7 @@ package SPVM::JSON {
     }
 
     # a recursion depth of ten gives us >>500 bits
-    _atof_scan1($json_str, $start, $end, \$accum, \$expo, 0, 10);
+    _atof_scan1($json_str, $start, \$accum, \$expo, 0, 10);
 
     if ($neg) {
       return -$accum;
@@ -275,7 +280,8 @@ package SPVM::JSON {
   }
 
   # https://metacpan.org/pod/Cpanel::JSON::XS#number
-  precompile private sub _decode_num : object ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_num : object ($self : self, $json_str : string, $iter : int&) {
+    my $end = length $json_str;
     if ($json_str->[$$iter] == 'n') {
       if ($$iter + 2 < $end && substr($json_str, $$iter, 3) eq "nan") {
         $$iter += 3;
@@ -284,7 +290,7 @@ package SPVM::JSON {
         $$iter += 4;
       }
       else {
-        _custom_die("malformed number.", $json_str, $$iter, $end);
+        _custom_die("malformed number.", $json_str, $$iter);
       }
       return undef;
     }
@@ -302,7 +308,7 @@ package SPVM::JSON {
         $$iter += 3;
       }
       else {
-        _custom_die("malformed number.", $json_str, $$iter, $end);
+        _custom_die("malformed number.", $json_str, $$iter);
       }
       return undef;
     }
@@ -310,11 +316,11 @@ package SPVM::JSON {
     if ($json_str->[$$iter] == '0') {
       ++$$iter;
       if ($$iter < $end && ($json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9')) {
-        _custom_die("malformed number (leading zero must not be followed by another digit)", $json_str, $$iter, $end);
+        _custom_die("malformed number (leading zero must not be followed by another digit)", $json_str, $$iter);
       }
     }
     elsif ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
-      _custom_die ("malformed number (no digits after initial minus)", $json_str, $$iter, $end);
+      _custom_die ("malformed number (no digits after initial minus)", $json_str, $$iter);
     }
 
     while ($$iter < $end && $json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9') {
@@ -325,7 +331,7 @@ package SPVM::JSON {
     if ($$iter < $end && $json_str->[$$iter] == '.') {
       ++$$iter;
       if ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
-        _custom_die ("malformed number (no digits after decimal point)", $json_str, $$iter, $end);
+        _custom_die ("malformed number (no digits after decimal point)", $json_str, $$iter);
       }
       while ($$iter < $end && $json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9') {
         ++$$iter;
@@ -343,7 +349,7 @@ package SPVM::JSON {
       }
 
       if ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
-        _custom_die ("malformed number (no digits after exp sign)", $json_str, $$iter, $end);
+        _custom_die ("malformed number (no digits after exp sign)", $json_str, $$iter);
       }
 
       while ($$iter < $end && ($json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9')) {
@@ -433,7 +439,7 @@ package SPVM::JSON {
 
       # does not fit into long, try double
       if (DBL_DIG() >= $len) {
-        return _atof($json_str, $start, $end);
+        return _atof($json_str, $start);
       }
 
       # everything else fails, convert it to a string
@@ -441,29 +447,30 @@ package SPVM::JSON {
     }
 
     # loss of precision here
-    return _atof($json_str, $start, $end);
+    return _atof($json_str, $start);
   }
 
-  precompile private sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
-    _expect_token($json_str, $iter, $end, "true");
+  precompile private sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&) {
+    _expect_token($json_str, $iter, "true");
     return SPVM::JSON::Bool->TRUE;
   }
 
-  precompile private sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
-    _expect_token($json_str, $iter, $end, "false");
+  precompile private sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&) {
+    _expect_token($json_str, $iter, "false");
     return SPVM::JSON::Bool->FALSE;
   }
 
-  precompile private sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $iter : int&) {
+    my $end = length $json_str;
     my $hash = SPVM::Hash->new;
     my $has_element = 0;
 
-    _expect_token($json_str, $iter, $end, "{");
+    _expect_token($json_str, $iter, "{");
 
     while (1) {
-      $self->_skip_spaces($json_str, $iter, $end);
+      $self->_skip_spaces($json_str, $iter);
       if ($$iter == $end) {
-        _custom_die("Incomplete object in JSON: end of string", $json_str, $$iter, $end);
+        _custom_die("Incomplete object in JSON: end of string", $json_str, $$iter);
       }
 
       # end of hash
@@ -473,40 +480,41 @@ package SPVM::JSON {
 
       # comma
       if ($has_element) {
-        _expect_token($json_str, $iter, $end, ",");
-        $self->_skip_spaces($json_str, $iter, $end);
+        _expect_token($json_str, $iter, ",");
+        $self->_skip_spaces($json_str, $iter);
       }
       else {
         $has_element = 1;
       }
 
       # key
-      my $key = $self->_decode_string($json_str, $iter, $end);
+      my $key = $self->_decode_string($json_str, $iter);
 
       # separator
-      $self->_skip_spaces($json_str, $iter, $end);
-      _expect_token($json_str, $iter, $end, ":");
+      $self->_skip_spaces($json_str, $iter);
+      _expect_token($json_str, $iter, ":");
 
       # value
-      $self->_skip_spaces($json_str, $iter, $end);
-      $hash->set($key, $self->_decode_recursive($json_str, $iter, $end));
+      $self->_skip_spaces($json_str, $iter);
+      $hash->set($key, $self->_decode_recursive($json_str, $iter));
     }
 
-    _expect_token($json_str, $iter, $end, "}");
+    _expect_token($json_str, $iter, "}");
 
     return $hash;
   }
 
-  precompile private sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $iter : int&, $end : int) {
+  precompile private sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $iter : int&) {
+    my $end = length $json_str;
     my $list = SPVM::ObjectList->new;
     my $has_element = 0;
 
-    _expect_token($json_str, $iter, $end, "[");
+    _expect_token($json_str, $iter, "[");
 
     while (1) {
-      $self->_skip_spaces($json_str, $iter, $end);
+      $self->_skip_spaces($json_str, $iter);
       if ($$iter == $end) {
-        _custom_die("Incomplete array in JSON: end of string", $json_str, $$iter, $end);
+        _custom_die("Incomplete array in JSON: end of string", $json_str, $$iter);
       }
 
       # end of list
@@ -516,57 +524,59 @@ package SPVM::JSON {
 
       # comma
       if ($has_element) {
-        _expect_token($json_str, $iter, $end, ",");
-        $self->_skip_spaces($json_str, $iter, $end);
+        _expect_token($json_str, $iter, ",");
+        $self->_skip_spaces($json_str, $iter);
       }
       else {
         $has_element = 1;
       }
-      $list->push($self->_decode_recursive($json_str, $iter, $end));
+      $list->push($self->_decode_recursive($json_str, $iter));
     }
 
-    _expect_token($json_str, $iter, $end, "]");
+    _expect_token($json_str, $iter, "]");
 
     return $list;
   }
 
-  precompile private sub _decode_recursive : object ($self : self, $json_str : string, $iter : int&, $end : int) {
-    $self->_skip_spaces($json_str, $iter, $end);
+  precompile private sub _decode_recursive : object ($self : self, $json_str : string, $iter : int&) {
+    my $end = length $json_str;
+
+    $self->_skip_spaces($json_str, $iter);
     if ($$iter == $end) {
-      _custom_die("Incomplete JSON", $json_str, $$iter, $end);
+      _custom_die("Incomplete JSON", $json_str, $$iter);
     }
 
     my $c = (int)($json_str->[$$iter]);
     switch ($c) {
       case '{': {
         # objects
-        return $self->_decode_hash($json_str, $iter, $end);
+        return $self->_decode_hash($json_str, $iter);
         break;
       }
       case '[': {
-        return $self->_decode_list($json_str, $iter, $end);
+        return $self->_decode_list($json_str, $iter);
         break;
       }
       case '"': {
-        return $self->_decode_string($json_str, $iter, $end);
+        return $self->_decode_string($json_str, $iter);
         break;
       }
       case '-': case 'i': case 'n':
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
-        return $self->_decode_num($json_str, $iter, $end);
+        return $self->_decode_num($json_str, $iter);
         break;
       }
       case 't': {
-        return $self->_decode_true($json_str, $iter, $end);
+        return $self->_decode_true($json_str, $iter);
         break;
       }
       case 'f': {
-        return $self->_decode_false($json_str, $iter, $end);
+        return $self->_decode_false($json_str, $iter);
         break;
       }
       default: {
-        _custom_die("Unexpected token.", $json_str, $$iter, $end);
+        _custom_die("Unexpected token.", $json_str, $$iter);
       }
     }
   }
@@ -717,14 +727,14 @@ package SPVM::JSON {
   precompile sub decode : object ($self : self, $json_text : string) {
     my $length = length $json_text;
     my $iter = 0;
-    $self->_skip_spaces($json_text, \$iter, $length);
+    $self->_skip_spaces($json_text, \$iter);
     if ($iter == $length) {
       return undef;
     }
-    my $ret = $self->_decode_recursive($json_text, \$iter, $length);
-    $self->_skip_spaces($json_text, \$iter, $length);
+    my $ret = $self->_decode_recursive($json_text, \$iter);
+    $self->_skip_spaces($json_text, \$iter);
     unless ($iter == $length) {
-      _custom_die("Not all json_text is decoded yet", $json_text, $iter, $length);
+      _custom_die("Not all json_text is decoded yet", $json_text, $iter);
     }
     return $ret;
   }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -29,50 +29,50 @@ package SPVM::JSON {
     die $die_message . "\nRemains... '$remains'";
   }
 
-  sub _skip_spaces : void ($self : self, $json_str : string, $i : int&, $end : int) {
-    for (; 1 ; ++$$i) {
-      if ($$i == $end) {
+  sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&, $end : int) {
+    for (; 1 ; ++$$iter) {
+      if ($$iter == $end) {
         return;
       }
-      unless ($json_str->[$$i] == ' ' || $json_str->[$$i] == '\n' || $json_str->[$$i] == '\t' || $json_str->[$$i] == '\r') {
+      unless ($json_str->[$$iter] == ' ' || $json_str->[$$iter] == '\n' || $json_str->[$$iter] == '\t' || $json_str->[$$iter] == '\r') {
         last;
       }
     }
   }
 
-  sub _skip_spaces_at_not_end : void ($self : self, $json_str : string, $i : int&, $end : int) {
-    $self->_skip_spaces($json_str, $i, $end);
-    if ($$i == $end) {
-      ERR("Incomplete JSON", $json_str, $$i, $end);
+  sub _skip_spaces_at_not_end : void ($self : self, $json_str : string, $iter : int&, $end : int) {
+    $self->_skip_spaces($json_str, $iter, $end);
+    if ($$iter == $end) {
+      ERR("Incomplete JSON", $json_str, $$iter, $end);
     }
   }
 
-  sub _expect_token : void ($json_str : string, $i : int&, $end : int, $expected : string) {
+  sub _expect_token : void ($json_str : string, $iter : int&, $end : int, $expected : string) {
     my $length = length $expected;
-    unless ($$i + $length <= $end) {
-      ERR("Expected token: $expected doesn't exist", $json_str, $$i, $end);
+    unless ($$iter + $length <= $end) {
+      ERR("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
     }
-    my $begin = $$i;
+    my $begin = $$iter;
     while (1) {
-      unless ($json_str->[$$i] == $expected->[$$i - $begin]) {
-        ERR("Expected token: $expected doesn't exist", $json_str, $$i, $end);
+      unless ($json_str->[$$iter] == $expected->[$$iter - $begin]) {
+        ERR("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
       }
-      ++$$i;
-      if ($$i - $begin == $length) {
+      ++$$iter;
+      if ($$iter - $begin == $length) {
         last;
       }
     }
   }
 
-  sub _decode_string : string ($self : self, $json_str : string, $i : int&, $end : int) {
+  sub _decode_string : string ($self : self, $json_str : string, $iter : int&, $end : int) {
     my $chars = SPVM::ObjectList->new;
-    _expect_token($json_str, $i, $end, "\"");
+    _expect_token($json_str, $iter, $end, "\"");
     my $special_char_expected = 0;
     while (1) {
-      if ($$i >= $end || (!$special_char_expected && $json_str->[$$i] == '"')) {
+      if ($$iter >= $end || (!$special_char_expected && $json_str->[$$iter] == '"')) {
         last;
       }
-      my $got_char = $json_str->[$$i];
+      my $got_char = $json_str->[$$iter];
       if ($special_char_expected) {
         switch ((int)$got_char) {
           case 34: # '"'
@@ -94,7 +94,7 @@ package SPVM::JSON {
             break;
           }
           default: {
-            ERR("Undefined special char", $json_str, $$i, $end);
+            ERR("Undefined special char", $json_str, $$iter, $end);
           }
         }
         $special_char_expected = 0;
@@ -104,16 +104,16 @@ package SPVM::JSON {
       }
       else {
         if ($got_char == '\t') {
-          ERR("Literal ASCII tab characters are not allowed in string", $json_str, $$i, $end);
+          ERR("Literal ASCII tab characters are not allowed in string", $json_str, $$iter, $end);
         }
         $chars->push(SPVM::Int->new($got_char));
       }
-      ++$$i;
+      ++$$iter;
     }
-    if ($$i == $end) {
-      ERR("Invalid string. end-quote doesn't exist", $json_str, $$i, $end);
+    if ($$iter == $end) {
+      ERR("Invalid string. end-quote doesn't exist", $json_str, $$iter, $end);
     }
-    _expect_token($json_str, $i, $end, "\"");
+    _expect_token($json_str, $iter, $end, "\"");
     my $chars_length = $chars->length;
     my $value = new byte [$chars_length];
     for (my $k = 0; $k < $chars_length; ++$k) {
@@ -123,7 +123,7 @@ package SPVM::JSON {
     return (string)$value;
   }
 
-  sub _atof_scan1 : double ($json_str : string, $i : int, $end : int,
+  sub _atof_scan1 : double ($json_str : string, $iter : int, $end : int,
       $accum : double&, $expo : int&, $postdp : int, $maxdepth : int) {
     my $long_accum : long = 0;
     my $expo_accum = 0;
@@ -131,43 +131,43 @@ package SPVM::JSON {
     # if we recurse too deep, skip all remaining digits
     # to avoid a stack overflow attack
     if (--$maxdepth <= 0) {
-      while ($i < $end && ($json_str->[$i] - '0') < 10) {
-        ++$i;
+      while ($iter < $end && ($json_str->[$iter] - '0') < 10) {
+        ++$iter;
       }
     }
 
-    while ($i < $end) {
-      if ($json_str->[$i] == '.') {
-        ++$i;
-        _atof_scan1($json_str, $i, $end, $accum, $expo, 1, $maxdepth);
+    while ($iter < $end) {
+      if ($json_str->[$iter] == '.') {
+        ++$iter;
+        _atof_scan1($json_str, $iter, $end, $accum, $expo, 1, $maxdepth);
         last;
       }
-      elsif ($json_str->[$i] == 'e' || $json_str->[$i] == 'E') {
+      elsif ($json_str->[$iter] == 'e' || $json_str->[$iter] == 'E') {
         my $exp2 = 0;
         my $neg = 0;
 
-        ++$i;
+        ++$iter;
 
-        if ($i >= $end) {
-          ERR ("malformed number (no digits after e/E)", $json_str, $i, $end);
+        if ($iter >= $end) {
+          ERR ("malformed number (no digits after e/E)", $json_str, $iter, $end);
         }
 
-        if ($json_str->[$i] == '-') {
-          ++$i;
+        if ($json_str->[$iter] == '-') {
+          ++$iter;
           $neg = 1;
         }
-        elsif ($json_str->[$i] == '+') {
-          ++$i;
+        elsif ($json_str->[$iter] == '+') {
+          ++$iter;
         }
 
-        if ($i >= $end) {
-          ERR ("malformed number (no digits after e/E)", $json_str, $i, $end);
+        if ($iter >= $end) {
+          ERR ("malformed number (no digits after e/E)", $json_str, $iter, $end);
         }
 
-        while ($i < $end) {
-          my $dig = $json_str->[$i] - '0';
+        while ($iter < $end) {
+          my $dig = $json_str->[$iter] - '0';
           if ($dig < 10) {
-            $exp2 = $exp2 * 10 + $json_str->[$i++] - '0';
+            $exp2 = $exp2 * 10 + $json_str->[$iter++] - '0';
           }
           else {
             last;
@@ -182,10 +182,10 @@ package SPVM::JSON {
         }
         last;
       }
-      elsif ($json_str->[$i] >= '0' && $json_str->[$i] <= '9') {
-        my $dig = $json_str->[$i] - '0';
+      elsif ($json_str->[$iter] >= '0' && $json_str->[$iter] <= '9') {
+        my $dig = $json_str->[$iter] - '0';
 
-        ++$i;
+        ++$iter;
 
         $long_accum = $long_accum * 10 + $dig;
         ++$expo_accum;
@@ -196,7 +196,7 @@ package SPVM::JSON {
           if ($postdp) {
             $$expo -= $expo_accum;
           }
-          _atof_scan1($json_str, $i, $end, $accum, $expo, $postdp, $maxdepth);
+          _atof_scan1($json_str, $iter, $end, $accum, $expo, $postdp, $maxdepth);
           if ($postdp) {
             $$expo += $expo_accum;
           }
@@ -238,86 +238,86 @@ package SPVM::JSON {
   }
 
   # https://metacpan.org/pod/Cpanel::JSON::XS#number
-  sub _decode_num : object ($self : self, $json_str : string, $i : int&, $end : int) {
-    if ($json_str->[$$i] == 'n') {
-      if ($$i + 2 < $end && substr($json_str, $$i, 3) eq "nan") {
-        $$i += 3;
+  sub _decode_num : object ($self : self, $json_str : string, $iter : int&, $end : int) {
+    if ($json_str->[$$iter] == 'n') {
+      if ($$iter + 2 < $end && substr($json_str, $$iter, 3) eq "nan") {
+        $$iter += 3;
       }
-      elsif ($$i + 3 < $end && substr($json_str, $$i, 4) eq "null") {
-        $$i += 4;
+      elsif ($$iter + 3 < $end && substr($json_str, $$iter, 4) eq "null") {
+        $$iter += 4;
       }
       else {
-        ERR("malformed number.", $json_str, $$i, $end);
+        ERR("malformed number.", $json_str, $$iter, $end);
       }
       return undef;
     }
 
     my $is_double = 0;
-    my $start = $$i;
+    my $start = $$iter;
 
     # minus
-    if ($json_str->[$$i] == '-') {
-      ++$$i;
+    if ($json_str->[$$iter] == '-') {
+      ++$$iter;
     }
 
-    if ($json_str->[$$i] == 'i') {
-      if ($$i + 2 < $end && substr($json_str, $$i, 3) eq "inf") {
-        $$i += 3;
+    if ($json_str->[$$iter] == 'i') {
+      if ($$iter + 2 < $end && substr($json_str, $$iter, 3) eq "inf") {
+        $$iter += 3;
       }
       else {
-        ERR("malformed number.", $json_str, $$i, $end);
+        ERR("malformed number.", $json_str, $$iter, $end);
       }
       return undef;
     }
 
-    if ($json_str->[$$i] == '0') {
-      ++$$i;
-      if ($$i < $end && ($json_str->[$$i] >= '0' && $json_str->[$$i] <= '9')) {
-        ERR("malformed number (leading zero must not be followed by another digit)", $json_str, $$i, $end);
+    if ($json_str->[$$iter] == '0') {
+      ++$$iter;
+      if ($$iter < $end && ($json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9')) {
+        ERR("malformed number (leading zero must not be followed by another digit)", $json_str, $$iter, $end);
       }
     }
-    elsif ($$i >= $end || $json_str->[$$i] < '0' || $json_str->[$$i] > '9') {
-      ERR ("malformed number (no digits after initial minus)", $json_str, $$i, $end);
+    elsif ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
+      ERR ("malformed number (no digits after initial minus)", $json_str, $$iter, $end);
     }
 
-    while ($$i < $end && $json_str->[$$i] >= '0' && $json_str->[$$i] <= '9') {
-      ++$$i;
+    while ($$iter < $end && $json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9') {
+      ++$$iter;
     }
 
     # frac
-    if ($$i < $end && $json_str->[$$i] == '.') {
-      ++$$i;
-      if ($$i >= $end || $json_str->[$$i] < '0' || $json_str->[$$i] > '9') {
-        ERR ("malformed number (no digits after decimal point)", $json_str, $$i, $end);
+    if ($$iter < $end && $json_str->[$$iter] == '.') {
+      ++$$iter;
+      if ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
+        ERR ("malformed number (no digits after decimal point)", $json_str, $$iter, $end);
       }
-      while ($$i < $end && $json_str->[$$i] >= '0' && $json_str->[$$i] <= '9') {
-        ++$$i;
+      while ($$iter < $end && $json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9') {
+        ++$$iter;
       }
 
       $is_double = 1;
     }
 
     # exp
-    if ($$i < $end && ($json_str->[$$i] == 'e' || $json_str->[$$i] == 'E')) {
-      ++$$i;
+    if ($$iter < $end && ($json_str->[$$iter] == 'e' || $json_str->[$$iter] == 'E')) {
+      ++$$iter;
 
-      if ($$i < $end && ($json_str->[$$i] == '-' || $json_str->[$$i] == '+')) {
-        ++$$i;
+      if ($$iter < $end && ($json_str->[$$iter] == '-' || $json_str->[$$iter] == '+')) {
+        ++$$iter;
       }
 
-      if ($$i >= $end || $json_str->[$$i] < '0' || $json_str->[$$i] > '9') {
-        ERR ("malformed number (no digits after exp sign)", $json_str, $$i, $end);
+      if ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
+        ERR ("malformed number (no digits after exp sign)", $json_str, $$iter, $end);
       }
 
-      while ($$i < $end && ($json_str->[$$i] >= '0' && $json_str->[$$i] <= '9')) {
-        ++$$i;
+      while ($$iter < $end && ($json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9')) {
+        ++$$iter;
       }
 
       $is_double = 1;
     }
 
     if (!$is_double) {
-      my $len = $$i - $start;
+      my $len = $$iter - $start;
 
       if ($json_str->[$start] == '-') {
         switch ($len) {
@@ -441,116 +441,116 @@ package SPVM::JSON {
       }
 
       # everything else fails, convert it to a string
-      return substr($json_str, $start, $$i - $start);
+      return substr($json_str, $start, $$iter - $start);
     }
 
     # loss of precision here
     return _atof($json_str, $start, $end);
   }
 
-  sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $i : int&, $end : int) {
-    _expect_token($json_str, $i, $end, "true");
+  sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
+    _expect_token($json_str, $iter, $end, "true");
     return SPVM::JSON::Bool->TRUE;
   }
 
-  sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $i : int&, $end : int) {
-    _expect_token($json_str, $i, $end, "false");
+  sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
+    _expect_token($json_str, $iter, $end, "false");
     return SPVM::JSON::Bool->FALSE;
   }
 
-  sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $i : int&, $end : int) {
+  sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $iter : int&, $end : int) {
     my $hash = SPVM::Hash->new;
     my $has_element = 0;
-    _expect_token($json_str, $i, $end, "{");
+    _expect_token($json_str, $iter, $end, "{");
     while (1) {
       # end of hash
-      $self->_skip_spaces_at_not_end($json_str, $i, $end);
-      if ($json_str->[$$i] == '}') {
+      $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+      if ($json_str->[$$iter] == '}') {
         last;
       }
 
       # comma
       if ($has_element) {
-        _expect_token($json_str, $i, $end, ",");
-        $self->_skip_spaces_at_not_end($json_str, $i, $end);
+        _expect_token($json_str, $iter, $end, ",");
+        $self->_skip_spaces_at_not_end($json_str, $iter, $end);
       }
       else {
         $has_element = 1;
       }
 
       # key
-      my $key = $self->_decode_string($json_str, $i, $end);
+      my $key = $self->_decode_string($json_str, $iter, $end);
 
       # separator
-      $self->_skip_spaces_at_not_end($json_str, $i, $end);
-      _expect_token($json_str, $i, $end, ":");
+      $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+      _expect_token($json_str, $iter, $end, ":");
 
       # value
-      $self->_skip_spaces_at_not_end($json_str, $i, $end);
-      $hash->set($key, $self->_decode_recursive($json_str, $i, $end));
+      $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+      $hash->set($key, $self->_decode_recursive($json_str, $iter, $end));
     }
-    _expect_token($json_str, $i, $end, "}");
+    _expect_token($json_str, $iter, $end, "}");
     return $hash;
   }
 
-  sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $i : int&, $end : int) {
-    _expect_token($json_str, $i, $end, "[");
+  sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $iter : int&, $end : int) {
+    _expect_token($json_str, $iter, $end, "[");
     my $list = SPVM::ObjectList->new;
     my $has_element = 0;
     while (1) {
       # end of list
-      $self->_skip_spaces_at_not_end($json_str, $i, $end);
-      if ($json_str->[$$i] == ']') {
+      $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+      if ($json_str->[$$iter] == ']') {
         last;
       }
 
       # comma
       if ($has_element) {
-        _expect_token($json_str, $i, $end, ",");
-        $self->_skip_spaces_at_not_end($json_str, $i, $end);
+        _expect_token($json_str, $iter, $end, ",");
+        $self->_skip_spaces_at_not_end($json_str, $iter, $end);
       }
       else {
         $has_element = 1;
       }
-      $list->push($self->_decode_recursive($json_str, $i, $end));
+      $list->push($self->_decode_recursive($json_str, $iter, $end));
     }
-    _expect_token($json_str, $i, $end, "]");
+    _expect_token($json_str, $iter, $end, "]");
     return $list;
   }
 
-  sub _decode_recursive : object ($self : self, $json_str : string, $i : int&, $end : int) {
-    $self->_skip_spaces_at_not_end($json_str, $i, $end);
-    my $c = (int)($json_str->[$$i]);
+  sub _decode_recursive : object ($self : self, $json_str : string, $iter : int&, $end : int) {
+    $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+    my $c = (int)($json_str->[$$iter]);
     switch ($c) {
       case '{': {
         # objects
-        return $self->_decode_hash($json_str, $i, $end);
+        return $self->_decode_hash($json_str, $iter, $end);
         break;
       }
       case '[': {
-        return $self->_decode_list($json_str, $i, $end);
+        return $self->_decode_list($json_str, $iter, $end);
         break;
       }
       case '"': {
-        return $self->_decode_string($json_str, $i, $end);
+        return $self->_decode_string($json_str, $iter, $end);
         break;
       }
       case '-': case 'i': case 'n':
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
-        return $self->_decode_num($json_str, $i, $end);
+        return $self->_decode_num($json_str, $iter, $end);
         break;
       }
       case 't': {
-        return $self->_decode_true($json_str, $i, $end);
+        return $self->_decode_true($json_str, $iter, $end);
         break;
       }
       case 'f': {
-        return $self->_decode_false($json_str, $i, $end);
+        return $self->_decode_false($json_str, $iter, $end);
         break;
       }
       default: {
-        ERR("Unexpected token.", $json_str, $$i, $end);
+        ERR("Unexpected token.", $json_str, $$iter, $end);
       }
     }
   }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -21,7 +21,7 @@ package SPVM::JSON {
     LDBL_DIG = 18
   }
 
-  sub ERR : void ($die_message : string, $json_str : string, $start : int, $end : int) {
+  sub _custom_die : void ($die_message : string, $json_str : string, $start : int, $end : int) {
     my $max_dump_length = 10;
     if ($max_dump_length > $end - $start) {
       $max_dump_length = $end - $start;
@@ -47,19 +47,19 @@ package SPVM::JSON {
   sub _skip_spaces_at_not_end : void ($self : self, $json_str : string, $iter : int&, $end : int) {
     $self->_skip_spaces($json_str, $iter, $end);
     if ($$iter == $end) {
-      ERR("Incomplete JSON", $json_str, $$iter, $end);
+      _custom_die("Incomplete JSON", $json_str, $$iter, $end);
     }
   }
 
   sub _expect_token : void ($json_str : string, $iter : int&, $end : int, $expected : string) {
     my $length = length $expected;
     unless ($$iter + $length <= $end) {
-      ERR("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
+      _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
     }
     my $begin = $$iter;
     while (1) {
       unless ($json_str->[$$iter] == $expected->[$$iter - $begin]) {
-        ERR("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
+        _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
       }
       ++$$iter;
       if ($$iter - $begin == $length) {
@@ -98,7 +98,7 @@ package SPVM::JSON {
             break;
           }
           default: {
-            ERR("Undefined special char", $json_str, $$iter, $end);
+            _custom_die("Undefined special char", $json_str, $$iter, $end);
           }
         }
         $special_char_expected = 0;
@@ -108,14 +108,14 @@ package SPVM::JSON {
       }
       else {
         if ($got_char == '\t') {
-          ERR("Literal ASCII tab characters are not allowed in string", $json_str, $$iter, $end);
+          _custom_die("Literal ASCII tab characters are not allowed in string", $json_str, $$iter, $end);
         }
         $chars->push(SPVM::Int->new($got_char));
       }
       ++$$iter;
     }
     if ($$iter == $end) {
-      ERR("Invalid string. end-quote doesn't exist", $json_str, $$iter, $end);
+      _custom_die("Invalid string. end-quote doesn't exist", $json_str, $$iter, $end);
     }
     _expect_token($json_str, $iter, $end, "\"");
     my $chars_length = $chars->length;
@@ -153,7 +153,7 @@ package SPVM::JSON {
         ++$iter;
 
         if ($iter >= $end) {
-          ERR ("malformed number (no digits after e/E)", $json_str, $iter, $end);
+          _custom_die ("malformed number (no digits after e/E)", $json_str, $iter, $end);
         }
 
         if ($json_str->[$iter] == '-') {
@@ -165,7 +165,7 @@ package SPVM::JSON {
         }
 
         if ($iter >= $end) {
-          ERR ("malformed number (no digits after e/E)", $json_str, $iter, $end);
+          _custom_die ("malformed number (no digits after e/E)", $json_str, $iter, $end);
         }
 
         while ($iter < $end) {
@@ -251,7 +251,7 @@ package SPVM::JSON {
         $$iter += 4;
       }
       else {
-        ERR("malformed number.", $json_str, $$iter, $end);
+        _custom_die("malformed number.", $json_str, $$iter, $end);
       }
       return undef;
     }
@@ -269,7 +269,7 @@ package SPVM::JSON {
         $$iter += 3;
       }
       else {
-        ERR("malformed number.", $json_str, $$iter, $end);
+        _custom_die("malformed number.", $json_str, $$iter, $end);
       }
       return undef;
     }
@@ -277,11 +277,11 @@ package SPVM::JSON {
     if ($json_str->[$$iter] == '0') {
       ++$$iter;
       if ($$iter < $end && ($json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9')) {
-        ERR("malformed number (leading zero must not be followed by another digit)", $json_str, $$iter, $end);
+        _custom_die("malformed number (leading zero must not be followed by another digit)", $json_str, $$iter, $end);
       }
     }
     elsif ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
-      ERR ("malformed number (no digits after initial minus)", $json_str, $$iter, $end);
+      _custom_die ("malformed number (no digits after initial minus)", $json_str, $$iter, $end);
     }
 
     while ($$iter < $end && $json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9') {
@@ -292,7 +292,7 @@ package SPVM::JSON {
     if ($$iter < $end && $json_str->[$$iter] == '.') {
       ++$$iter;
       if ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
-        ERR ("malformed number (no digits after decimal point)", $json_str, $$iter, $end);
+        _custom_die ("malformed number (no digits after decimal point)", $json_str, $$iter, $end);
       }
       while ($$iter < $end && $json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9') {
         ++$$iter;
@@ -310,7 +310,7 @@ package SPVM::JSON {
       }
 
       if ($$iter >= $end || $json_str->[$$iter] < '0' || $json_str->[$$iter] > '9') {
-        ERR ("malformed number (no digits after exp sign)", $json_str, $$iter, $end);
+        _custom_die ("malformed number (no digits after exp sign)", $json_str, $$iter, $end);
       }
 
       while ($$iter < $end && ($json_str->[$$iter] >= '0' && $json_str->[$$iter] <= '9')) {
@@ -554,7 +554,7 @@ package SPVM::JSON {
         break;
       }
       default: {
-        ERR("Unexpected token.", $json_str, $$iter, $end);
+        _custom_die("Unexpected token.", $json_str, $$iter, $end);
       }
     }
   }
@@ -718,7 +718,7 @@ package SPVM::JSON {
     my $ret = $self->_decode_recursive($json_text, \$iter, $length);
     $self->_skip_spaces($json_text, \$iter, $length);
     unless ($iter == $length) {
-      ERR("Not all json_text is decoded yet", $json_text, $iter, $length);
+      _custom_die("Not all json_text is decoded yet", $json_text, $iter, $length);
     }
     return $ret;
   }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -241,6 +241,45 @@ package SPVM::JSON {
     }
   }
 
+  private sub _grok_non_neg : int ($json_str : string, $start : int, $len : int, $val : long&) {
+    my $number_type = 0;
+    $$val = 0;
+    for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
+      if ($$val <= (long)INT32_MAX()) {
+        $$val = $$val * 10 + $json_str->[$start + $digit_index] - '0';
+      }
+      elsif ($$val < INT64_MAX() / 10 ||
+          ($$val == INT64_MAX() / 10 && $json_str->[$start + $digit_index] - '0' <= INT64_MAX() % 10)) {
+        $number_type = 1;
+        $$val = $$val * 10 + $json_str->[$start + $digit_index] - '0';
+      }
+      else {
+        return -1;
+      }
+    }
+    return $number_type;
+  }
+
+  private sub _grok_neg : int ($json_str : string, $start : int, $len : int, $val : long&) {
+    my $number_type = 0;
+    $$val = 0;
+    for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
+      if ($$val >= (long)INT32_MIN()) {
+        $$val = $$val * 10 - ($json_str->[$start + $digit_index] - '0');
+      }
+      elsif ($$val > INT64_MIN() / 10 ||
+          ($$val == INT64_MIN() / 10 &&
+              $json_str->[$start + $digit_index] - '0' <= -(INT64_MIN() + INT64_MIN() / 10 * 10))) {
+        $number_type = 1;
+        $$val = $$val * 10 - ($json_str->[$start + $digit_index] - '0');
+      }
+      else {
+        return -1;
+      }
+    }
+    return $number_type;
+  }
+
   # https://metacpan.org/pod/Cpanel::JSON::XS#number
   private sub _decode_num : object ($self : self, $json_str : string, $iter : int&, $end : int) {
     if ($json_str->[$$iter] == 'n') {
@@ -372,52 +411,11 @@ package SPVM::JSON {
         }
       }
 
-      my $grok_non_neg = sub : int ($self : self,
-          $json_str : string, $start : int, $len : int, $val : long&) {
-        my $number_type = 0;
-        $$val = 0;
-        for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
-          if ($$val <= (long)INT32_MAX()) {
-            $$val = $$val * 10 + $json_str->[$start + $digit_index] - '0';
-          }
-          elsif ($$val < INT64_MAX() / 10 ||
-              ($$val == INT64_MAX() / 10 && $json_str->[$start + $digit_index] - '0' <= INT64_MAX() % 10)) {
-            $number_type = 1;
-            $$val = $$val * 10 + $json_str->[$start + $digit_index] - '0';
-          }
-          else {
-            return -1;
-          }
-        }
-        return $number_type;
-      };
-
-      my $grok_neg = sub : int ($self : self,
-          $json_str : string, $start : int, $len : int, $val : long&) {
-        my $number_type = 0;
-        $$val = 0;
-        for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
-          if ($$val >= (long)INT32_MIN()) {
-            $$val = $$val * 10 - ($json_str->[$start + $digit_index] - '0');
-          }
-          elsif ($$val > INT64_MIN() / 10 ||
-              ($$val == INT64_MIN() / 10 &&
-                  $json_str->[$start + $digit_index] - '0' <= -(INT64_MIN() + INT64_MIN() / 10 * 10))) {
-            $number_type = 1;
-            $$val = $$val * 10 - ($json_str->[$start + $digit_index] - '0');
-          }
-          else {
-            return -1;
-          }
-        }
-        return $number_type;
-      };
-
       my $val : long;
       my $number_type = 0;
 
       if ($json_str->[$start] == '-') {
-        $number_type = $grok_neg->($json_str, $start + 1, $len - 1, \$val);
+        $number_type = _grok_neg($json_str, $start + 1, $len - 1, \$val);
         if ($number_type == 0) {
           return (int)$val;
         }
@@ -426,7 +424,7 @@ package SPVM::JSON {
         }
       }
       else {
-        $number_type = $grok_non_neg->($json_str, $start, $len, \$val);
+        $number_type = _grok_non_neg($json_str, $start, $len, \$val);
         if ($number_type == 0) {
           return (int)$val;
         }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -372,14 +372,14 @@ package SPVM::JSON {
           $json_str : string, $start : int, $len : int, $val : long&) {
         my $number_type = 0;
         $$val = 0;
-        for (my $i = 0; $i < $len; ++$i) {
+        for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
           if ($$val <= (long)INT32_MAX()) {
-            $$val = $$val * 10 + $json_str->[$start + $i] - '0';
+            $$val = $$val * 10 + $json_str->[$start + $digit_index] - '0';
           }
           elsif ($$val < INT64_MAX() / 10 ||
-              ($$val == INT64_MAX() / 10 && $json_str->[$start + $i] - '0' <= INT64_MAX() % 10)) {
+              ($$val == INT64_MAX() / 10 && $json_str->[$start + $digit_index] - '0' <= INT64_MAX() % 10)) {
             $number_type = 1;
-            $$val = $$val * 10 + $json_str->[$start + $i] - '0';
+            $$val = $$val * 10 + $json_str->[$start + $digit_index] - '0';
           }
           else {
             return -1;
@@ -392,15 +392,15 @@ package SPVM::JSON {
           $json_str : string, $start : int, $len : int, $val : long&) {
         my $number_type = 0;
         $$val = 0;
-        for (my $i = 0; $i < $len; ++$i) {
+        for (my $digit_index = 0; $digit_index < $len; ++$digit_index) {
           if ($$val >= (long)INT32_MIN()) {
-            $$val = $$val * 10 - ($json_str->[$start + $i] - '0');
+            $$val = $$val * 10 - ($json_str->[$start + $digit_index] - '0');
           }
           elsif ($$val > INT64_MIN() / 10 ||
               ($$val == INT64_MIN() / 10 &&
-                  $json_str->[$start + $i] - '0' <= -(INT64_MIN() + INT64_MIN() / 10 * 10))) {
+                  $json_str->[$start + $digit_index] - '0' <= -(INT64_MIN() + INT64_MIN() / 10 * 10))) {
             $number_type = 1;
-            $$val = $$val * 10 - ($json_str->[$start + $i] - '0');
+            $$val = $$val * 10 - ($json_str->[$start + $digit_index] - '0');
           }
           else {
             return -1;
@@ -558,8 +558,8 @@ package SPVM::JSON {
   sub _escape_string : string ($string : string) {
     my $length = length $string;
     my $chars = SPVM::ObjectList->new;
-    for (my $i = 0; $i < $length; ++$i) {
-      my $got_char = (int)($string->[$i]);
+    for (my $str_index = 0; $str_index < $length; ++$str_index) {
+      my $got_char = (int)($string->[$str_index]);
       my $special = -1;
       switch ($got_char) {
         case 9: {# '\t'
@@ -618,14 +618,14 @@ package SPVM::JSON {
       if ($self->canonical) {
         sortstr($keys);
       }
-      for (my $i = 0; $i < @$keys; ++$i) {
-        if ($i > 0) {
+      for (my $keys_index = 0; $keys_index < @$keys; ++$keys_index) {
+        if ($keys_index > 0) {
           $buffer->push(",");
         }
         $buffer->push("\"");
-        $buffer->push($keys->[$i]);
+        $buffer->push($keys->[$keys_index]);
         $buffer->push("\":");
-        my $json_part = $self->_encode_recursive($hash->get($keys->[$i]), $depth + 1);
+        my $json_part = $self->_encode_recursive($hash->get($keys->[$keys_index]), $depth + 1);
         $buffer->push($json_part);
       }
       $buffer->push("}");
@@ -639,11 +639,11 @@ package SPVM::JSON {
       
       my $list = (SPVM::ObjectList)$spvm_data;
       my $length = $list->length;
-      for (my $i = 0; $i < $length; ++$i) {
-        if ($i > 0) {
+      for (my $list_index = 0; $list_index < $length; ++$list_index) {
+        if ($list_index > 0) {
           $buffer->push(",");
         }
-        my $json_part = $self->_encode_recursive($list->get($i), $depth + 1);
+        my $json_part = $self->_encode_recursive($list->get($list_index), $depth + 1);
         $buffer->push($json_part);
       }
       $buffer->push("]");

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -21,7 +21,7 @@ package SPVM::JSON {
     LDBL_DIG = 18
   }
 
-  sub _custom_die : void ($die_message : string, $json_str : string, $start : int, $end : int) {
+  private sub _custom_die : void ($die_message : string, $json_str : string, $start : int, $end : int) {
     my $max_dump_length = 10;
     if ($max_dump_length > $end - $start) {
       $max_dump_length = $end - $start;
@@ -33,7 +33,7 @@ package SPVM::JSON {
     die $die_message . " near: '$remains'";
   }
 
-  sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&, $end : int) {
+  private sub _skip_spaces : void ($self : self, $json_str : string, $iter : int&, $end : int) {
     for (; 1 ; ++$$iter) {
       if ($$iter == $end) {
         return;
@@ -44,14 +44,14 @@ package SPVM::JSON {
     }
   }
 
-  sub _skip_spaces_at_not_end : void ($self : self, $json_str : string, $iter : int&, $end : int) {
+  private sub _skip_spaces_at_not_end : void ($self : self, $json_str : string, $iter : int&, $end : int) {
     $self->_skip_spaces($json_str, $iter, $end);
     if ($$iter == $end) {
       _custom_die("Incomplete JSON", $json_str, $$iter, $end);
     }
   }
 
-  sub _expect_token : void ($json_str : string, $iter : int&, $end : int, $expected : string) {
+  private sub _expect_token : void ($json_str : string, $iter : int&, $end : int, $expected : string) {
     my $length = length $expected;
     unless ($$iter + $length <= $end) {
       _custom_die("Expected token: $expected doesn't exist", $json_str, $$iter, $end);
@@ -68,7 +68,7 @@ package SPVM::JSON {
     }
   }
 
-  sub _decode_string : string ($self : self, $json_str : string, $iter : int&, $end : int) {
+  private sub _decode_string : string ($self : self, $json_str : string, $iter : int&, $end : int) {
     my $chars = SPVM::ObjectList->new;
     _expect_token($json_str, $iter, $end, "\"");
     my $special_char_expected = 0;
@@ -127,7 +127,7 @@ package SPVM::JSON {
     return (string)$value;
   }
 
-  sub _atof_scan1 : double ($json_str : string, $iter : int, $end : int,
+  private sub _atof_scan1 : double ($json_str : string, $iter : int, $end : int,
       $accum : double&, $expo : int&, $postdp : int, $maxdepth : int) {
     my $long_accum : long = 0;
     my $expo_accum = 0;
@@ -220,7 +220,7 @@ package SPVM::JSON {
     $$expo += $expo_accum;
   }
 
-  sub _atof : double ($json_str : string, $start : int, $end : int) {
+  private sub _atof : double ($json_str : string, $start : int, $end : int) {
     my $accum = 0.0;
     my $expo = 0;
     my $neg = 0;
@@ -242,7 +242,7 @@ package SPVM::JSON {
   }
 
   # https://metacpan.org/pod/Cpanel::JSON::XS#number
-  sub _decode_num : object ($self : self, $json_str : string, $iter : int&, $end : int) {
+  private sub _decode_num : object ($self : self, $json_str : string, $iter : int&, $end : int) {
     if ($json_str->[$$iter] == 'n') {
       if ($$iter + 2 < $end && substr($json_str, $$iter, 3) eq "nan") {
         $$iter += 3;
@@ -452,17 +452,17 @@ package SPVM::JSON {
     return _atof($json_str, $start, $end);
   }
 
-  sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
+  private sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
     _expect_token($json_str, $iter, $end, "true");
     return SPVM::JSON::Bool->TRUE;
   }
 
-  sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
+  private sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $iter : int&, $end : int) {
     _expect_token($json_str, $iter, $end, "false");
     return SPVM::JSON::Bool->FALSE;
   }
 
-  sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $iter : int&, $end : int) {
+  private sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $iter : int&, $end : int) {
     my $hash = SPVM::Hash->new;
     my $has_element = 0;
     _expect_token($json_str, $iter, $end, "{");
@@ -497,7 +497,7 @@ package SPVM::JSON {
     return $hash;
   }
 
-  sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $iter : int&, $end : int) {
+  private sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $iter : int&, $end : int) {
     _expect_token($json_str, $iter, $end, "[");
     my $list = SPVM::ObjectList->new;
     my $has_element = 0;
@@ -522,7 +522,7 @@ package SPVM::JSON {
     return $list;
   }
 
-  sub _decode_recursive : object ($self : self, $json_str : string, $iter : int&, $end : int) {
+  private sub _decode_recursive : object ($self : self, $json_str : string, $iter : int&, $end : int) {
     $self->_skip_spaces_at_not_end($json_str, $iter, $end);
     my $c = (int)($json_str->[$$iter]);
     switch ($c) {
@@ -559,7 +559,7 @@ package SPVM::JSON {
     }
   }
 
-  sub _escape_string : string ($string : string) {
+  private sub _escape_string : string ($string : string) {
     my $length = length $string;
     my $chars = SPVM::ObjectList->new;
     for (my $str_index = 0; $str_index < $length; ++$str_index) {
@@ -605,7 +605,7 @@ package SPVM::JSON {
     return (string)$escaped;
   }
 
-  sub _encode_recursive : string ($self : self, $spvm_data : object, $depth : int) {
+  private sub _encode_recursive : string ($self : self, $spvm_data : object, $depth : int) {
     
     my $json : string;
     

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -567,11 +567,11 @@ package SPVM::JSON {
 
   precompile private sub _escape_string : string ($string : string) {
     my $length = length $string;
-    my $chars = SPVM::ObjectList->new;
-    for (my $str_index = 0; $str_index < $length; ++$str_index) {
-      my $got_char = (int)($string->[$str_index]);
-      my $special = -1;
-      switch ($got_char) {
+    my $buffer = SPVM::StringBuffer->new;
+    for (my $i = 0; $i < $length; ++$i) {
+      my $char = $string->[$i];
+      my $special : byte = -1;
+      switch ((int)$char) {
         case 9: {# '\t'
           # Note: Decoded char from literal ASCII tab will be encoded with "\\t" (non-reversible).
           $special = 't';
@@ -595,20 +595,14 @@ package SPVM::JSON {
         }
       }
       if ($special == -1) {
-        $chars->push(SPVM::Int->new($got_char));
+        $buffer->push_char($char);
       }
       else {
-        $chars->push(SPVM::Int->new('\\'));
-        $chars->push(SPVM::Int->new($special));
+        $buffer->push_char('\\');
+        $buffer->push_char($special);
       }
     }
-    my $chars_length = $chars->length;
-    my $escaped = new byte [$chars_length];
-    for (my $k = 0; $k < $chars_length; ++$k) {
-      my $got = ((SPVM::Int)$chars->shift)->val;
-      $escaped->[$k] = (byte)$got;
-    }
-    return (string)$escaped;
+    return $buffer->to_str;
   }
 
   precompile private sub _encode_recursive : string ($self : self, $spvm_data : object, $depth : int) {

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -65,32 +65,32 @@ package SPVM::JSON {
   }
 
   precompile private sub _decode_string : string ($self : self, $json_str : string, $iter : int&, $end : int) {
-    my $chars = SPVM::ObjectList->new;
+    my $buffer = SPVM::StringBuffer->new;
     _expect_token($json_str, $iter, $end, "\"");
     my $special_char_expected = 0;
     while (1) {
       if ($$iter >= $end || (!$special_char_expected && $json_str->[$$iter] == '"')) {
         last;
       }
-      my $got_char = $json_str->[$$iter];
+      my $char = $json_str->[$$iter];
       if ($special_char_expected) {
-        switch ((int)$got_char) {
+        switch ((int)$char) {
           case 34: # '"'
           case 92: # '\\'
           {
-            $chars->push(SPVM::Int->new($got_char));
+            $buffer->push_char($char);
             break;
           }
           case 116: { # 't'
-            $chars->push(SPVM::Int->new('\t'));
+            $buffer->push_char('\t');
             break;
           }
           case 110: { # 'n'
-            $chars->push(SPVM::Int->new('\n'));
+            $buffer->push_char('\n');
             break;
           }
           case 114: { # 'r'
-            $chars->push(SPVM::Int->new('\r'));
+            $buffer->push_char('\r');
             break;
           }
           default: {
@@ -99,14 +99,14 @@ package SPVM::JSON {
         }
         $special_char_expected = 0;
       }
-      elsif ($got_char == '\\') {
+      elsif ($char == '\\') {
         $special_char_expected = 1;
       }
       else {
-        if ($got_char == '\t') {
+        if ($char == '\t') {
           _custom_die("Literal ASCII tab characters are not allowed in string", $json_str, $$iter, $end);
         }
-        $chars->push(SPVM::Int->new($got_char));
+        $buffer->push_char($char);
       }
       ++$$iter;
     }
@@ -114,13 +114,7 @@ package SPVM::JSON {
       _custom_die("Invalid string. end-quote doesn't exist", $json_str, $$iter, $end);
     }
     _expect_token($json_str, $iter, $end, "\"");
-    my $chars_length = $chars->length;
-    my $value = new byte [$chars_length];
-    for (my $k = 0; $k < $chars_length; ++$k) {
-      my $got = ((SPVM::Int)$chars->shift)->val;
-      $value->[$k] = (byte)$got;
-    }
-    return (string)$value;
+    return (string)$buffer->to_str;
   }
 
   precompile private sub _atof_scan1 : double ($json_str : string, $iter : int, $end : int,

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -21,41 +21,41 @@ package SPVM::JSON {
     LDBL_DIG = 18
   }
 
-  sub ERR : void ($die_message : string, $s : string, $start : int, $end : int) {
+  sub ERR : void ($die_message : string, $json_str : string, $start : int, $end : int) {
     my $remains = "";
     if ($end - $start >= 0) {
-      $remains = substr($s, $start, $end - $start);
+      $remains = substr($json_str, $start, $end - $start);
     }
     die $die_message . "\nRemains... '$remains'";
   }
 
-  sub _skip_spaces : void ($self : self, $s : string, $i : int&, $end : int) {
+  sub _skip_spaces : void ($self : self, $json_str : string, $i : int&, $end : int) {
     for (; 1 ; ++$$i) {
       if ($$i == $end) {
         return;
       }
-      unless ($s->[$$i] == ' ' || $s->[$$i] == '\n' || $s->[$$i] == '\t' || $s->[$$i] == '\r') {
+      unless ($json_str->[$$i] == ' ' || $json_str->[$$i] == '\n' || $json_str->[$$i] == '\t' || $json_str->[$$i] == '\r') {
         last;
       }
     }
   }
 
-  sub _skip_spaces_at_not_end : void ($self : self, $s : string, $i : int&, $end : int) {
-    $self->_skip_spaces($s, $i, $end);
+  sub _skip_spaces_at_not_end : void ($self : self, $json_str : string, $i : int&, $end : int) {
+    $self->_skip_spaces($json_str, $i, $end);
     if ($$i == $end) {
-      ERR("Incomplete JSON", $s, $$i, $end);
+      ERR("Incomplete JSON", $json_str, $$i, $end);
     }
   }
 
-  sub _expect_token : void ($s : string, $i : int&, $end : int, $expected : string) {
+  sub _expect_token : void ($json_str : string, $i : int&, $end : int, $expected : string) {
     my $length = length $expected;
     unless ($$i + $length <= $end) {
-      ERR("Expected token: $expected doesn't exist", $s, $$i, $end);
+      ERR("Expected token: $expected doesn't exist", $json_str, $$i, $end);
     }
     my $begin = $$i;
     while (1) {
-      unless ($s->[$$i] == $expected->[$$i - $begin]) {
-        ERR("Expected token: $expected doesn't exist", $s, $$i, $end);
+      unless ($json_str->[$$i] == $expected->[$$i - $begin]) {
+        ERR("Expected token: $expected doesn't exist", $json_str, $$i, $end);
       }
       ++$$i;
       if ($$i - $begin == $length) {
@@ -64,15 +64,15 @@ package SPVM::JSON {
     }
   }
 
-  sub _decode_string : string ($self : self, $s : string, $i : int&, $end : int) {
+  sub _decode_string : string ($self : self, $json_str : string, $i : int&, $end : int) {
     my $chars = SPVM::ObjectList->new;
-    _expect_token($s, $i, $end, "\"");
+    _expect_token($json_str, $i, $end, "\"");
     my $special_char_expected = 0;
     while (1) {
-      if ($$i >= $end || (!$special_char_expected && $s->[$$i] == '"')) {
+      if ($$i >= $end || (!$special_char_expected && $json_str->[$$i] == '"')) {
         last;
       }
-      my $got_char = $s->[$$i];
+      my $got_char = $json_str->[$$i];
       if ($special_char_expected) {
         switch ((int)$got_char) {
           case 34: # '"'
@@ -94,7 +94,7 @@ package SPVM::JSON {
             break;
           }
           default: {
-            ERR("Undefined special char", $s, $$i, $end);
+            ERR("Undefined special char", $json_str, $$i, $end);
           }
         }
         $special_char_expected = 0;
@@ -104,16 +104,16 @@ package SPVM::JSON {
       }
       else {
         if ($got_char == '\t') {
-          ERR("Literal ASCII tab characters are not allowed in string", $s, $$i, $end);
+          ERR("Literal ASCII tab characters are not allowed in string", $json_str, $$i, $end);
         }
         $chars->push(SPVM::Int->new($got_char));
       }
       ++$$i;
     }
     if ($$i == $end) {
-      ERR("Invalid string. end-quote doesn't exist", $s, $$i, $end);
+      ERR("Invalid string. end-quote doesn't exist", $json_str, $$i, $end);
     }
-    _expect_token($s, $i, $end, "\"");
+    _expect_token($json_str, $i, $end, "\"");
     my $chars_length = $chars->length;
     my $value = new byte [$chars_length];
     for (my $k = 0; $k < $chars_length; ++$k) {
@@ -123,7 +123,7 @@ package SPVM::JSON {
     return (string)$value;
   }
 
-  sub _atof_scan1 : double ($s : string, $i : int, $end : int,
+  sub _atof_scan1 : double ($json_str : string, $i : int, $end : int,
       $accum : double&, $expo : int&, $postdp : int, $maxdepth : int) {
     my $long_accum : long = 0;
     my $expo_accum = 0;
@@ -131,43 +131,43 @@ package SPVM::JSON {
     # if we recurse too deep, skip all remaining digits
     # to avoid a stack overflow attack
     if (--$maxdepth <= 0) {
-      while ($i < $end && ($s->[$i] - '0') < 10) {
+      while ($i < $end && ($json_str->[$i] - '0') < 10) {
         ++$i;
       }
     }
 
     while ($i < $end) {
-      if ($s->[$i] == '.') {
+      if ($json_str->[$i] == '.') {
         ++$i;
-        _atof_scan1($s, $i, $end, $accum, $expo, 1, $maxdepth);
+        _atof_scan1($json_str, $i, $end, $accum, $expo, 1, $maxdepth);
         last;
       }
-      elsif ($s->[$i] == 'e' || $s->[$i] == 'E') {
+      elsif ($json_str->[$i] == 'e' || $json_str->[$i] == 'E') {
         my $exp2 = 0;
         my $neg = 0;
 
         ++$i;
 
         if ($i >= $end) {
-          ERR ("malformed number (no digits after e/E)", $s, $i, $end);
+          ERR ("malformed number (no digits after e/E)", $json_str, $i, $end);
         }
 
-        if ($s->[$i] == '-') {
+        if ($json_str->[$i] == '-') {
           ++$i;
           $neg = 1;
         }
-        elsif ($s->[$i] == '+') {
+        elsif ($json_str->[$i] == '+') {
           ++$i;
         }
 
         if ($i >= $end) {
-          ERR ("malformed number (no digits after e/E)", $s, $i, $end);
+          ERR ("malformed number (no digits after e/E)", $json_str, $i, $end);
         }
 
         while ($i < $end) {
-          my $dig = $s->[$i] - '0';
+          my $dig = $json_str->[$i] - '0';
           if ($dig < 10) {
-            $exp2 = $exp2 * 10 + $s->[$i++] - '0';
+            $exp2 = $exp2 * 10 + $json_str->[$i++] - '0';
           }
           else {
             last;
@@ -182,8 +182,8 @@ package SPVM::JSON {
         }
         last;
       }
-      elsif ($s->[$i] >= '0' && $s->[$i] <= '9') {
-        my $dig = $s->[$i] - '0';
+      elsif ($json_str->[$i] >= '0' && $json_str->[$i] <= '9') {
+        my $dig = $json_str->[$i] - '0';
 
         ++$i;
 
@@ -196,7 +196,7 @@ package SPVM::JSON {
           if ($postdp) {
             $$expo -= $expo_accum;
           }
-          _atof_scan1($s, $i, $end, $accum, $expo, $postdp, $maxdepth);
+          _atof_scan1($json_str, $i, $end, $accum, $expo, $postdp, $maxdepth);
           if ($postdp) {
             $$expo += $expo_accum;
           }
@@ -216,18 +216,18 @@ package SPVM::JSON {
     $$expo += $expo_accum;
   }
 
-  sub _atof : double ($s : string, $start : int, $end : int) {
+  sub _atof : double ($json_str : string, $start : int, $end : int) {
     my $accum = 0.0;
     my $expo = 0;
     my $neg = 0;
 
-    if ($s->[$start] == '-') {
+    if ($json_str->[$start] == '-') {
       ++$start;
       $neg = 1;
     }
 
     # a recursion depth of ten gives us >>500 bits
-    _atof_scan1($s, $start, $end, \$accum, \$expo, 0, 10);
+    _atof_scan1($json_str, $start, $end, \$accum, \$expo, 0, 10);
 
     if ($neg) {
       return -$accum;
@@ -238,16 +238,16 @@ package SPVM::JSON {
   }
 
   # https://metacpan.org/pod/Cpanel::JSON::XS#number
-  sub _decode_num : object ($self : self, $s : string, $i : int&, $end : int) {
-    if ($s->[$$i] == 'n') {
-      if ($$i + 2 < $end && substr($s, $$i, 3) eq "nan") {
+  sub _decode_num : object ($self : self, $json_str : string, $i : int&, $end : int) {
+    if ($json_str->[$$i] == 'n') {
+      if ($$i + 2 < $end && substr($json_str, $$i, 3) eq "nan") {
         $$i += 3;
       }
-      elsif ($$i + 3 < $end && substr($s, $$i, 4) eq "null") {
+      elsif ($$i + 3 < $end && substr($json_str, $$i, 4) eq "null") {
         $$i += 4;
       }
       else {
-        ERR("malformed number.", $s, $$i, $end);
+        ERR("malformed number.", $json_str, $$i, $end);
       }
       return undef;
     }
@@ -256,41 +256,41 @@ package SPVM::JSON {
     my $start = $$i;
 
     # minus
-    if ($s->[$$i] == '-') {
+    if ($json_str->[$$i] == '-') {
       ++$$i;
     }
 
-    if ($s->[$$i] == 'i') {
-      if ($$i + 2 < $end && substr($s, $$i, 3) eq "inf") {
+    if ($json_str->[$$i] == 'i') {
+      if ($$i + 2 < $end && substr($json_str, $$i, 3) eq "inf") {
         $$i += 3;
       }
       else {
-        ERR("malformed number.", $s, $$i, $end);
+        ERR("malformed number.", $json_str, $$i, $end);
       }
       return undef;
     }
 
-    if ($s->[$$i] == '0') {
+    if ($json_str->[$$i] == '0') {
       ++$$i;
-      if ($$i < $end && ($s->[$$i] >= '0' && $s->[$$i] <= '9')) {
-        ERR("malformed number (leading zero must not be followed by another digit)", $s, $$i, $end);
+      if ($$i < $end && ($json_str->[$$i] >= '0' && $json_str->[$$i] <= '9')) {
+        ERR("malformed number (leading zero must not be followed by another digit)", $json_str, $$i, $end);
       }
     }
-    elsif ($$i >= $end || $s->[$$i] < '0' || $s->[$$i] > '9') {
-      ERR ("malformed number (no digits after initial minus)", $s, $$i, $end);
+    elsif ($$i >= $end || $json_str->[$$i] < '0' || $json_str->[$$i] > '9') {
+      ERR ("malformed number (no digits after initial minus)", $json_str, $$i, $end);
     }
 
-    while ($$i < $end && $s->[$$i] >= '0' && $s->[$$i] <= '9') {
+    while ($$i < $end && $json_str->[$$i] >= '0' && $json_str->[$$i] <= '9') {
       ++$$i;
     }
 
     # frac
-    if ($$i < $end && $s->[$$i] == '.') {
+    if ($$i < $end && $json_str->[$$i] == '.') {
       ++$$i;
-      if ($$i >= $end || $s->[$$i] < '0' || $s->[$$i] > '9') {
-        ERR ("malformed number (no digits after decimal point)", $s, $$i, $end);
+      if ($$i >= $end || $json_str->[$$i] < '0' || $json_str->[$$i] > '9') {
+        ERR ("malformed number (no digits after decimal point)", $json_str, $$i, $end);
       }
-      while ($$i < $end && $s->[$$i] >= '0' && $s->[$$i] <= '9') {
+      while ($$i < $end && $json_str->[$$i] >= '0' && $json_str->[$$i] <= '9') {
         ++$$i;
       }
 
@@ -298,18 +298,18 @@ package SPVM::JSON {
     }
 
     # exp
-    if ($$i < $end && ($s->[$$i] == 'e' || $s->[$$i] == 'E')) {
+    if ($$i < $end && ($json_str->[$$i] == 'e' || $json_str->[$$i] == 'E')) {
       ++$$i;
 
-      if ($$i < $end && ($s->[$$i] == '-' || $s->[$$i] == '+')) {
+      if ($$i < $end && ($json_str->[$$i] == '-' || $json_str->[$$i] == '+')) {
         ++$$i;
       }
 
-      if ($$i >= $end || $s->[$$i] < '0' || $s->[$$i] > '9') {
-        ERR ("malformed number (no digits after exp sign)", $s, $$i, $end);
+      if ($$i >= $end || $json_str->[$$i] < '0' || $json_str->[$$i] > '9') {
+        ERR ("malformed number (no digits after exp sign)", $json_str, $$i, $end);
       }
 
-      while ($$i < $end && ($s->[$$i] >= '0' && $s->[$$i] <= '9')) {
+      while ($$i < $end && ($json_str->[$$i] >= '0' && $json_str->[$$i] <= '9')) {
         ++$$i;
       }
 
@@ -319,26 +319,26 @@ package SPVM::JSON {
     if (!$is_double) {
       my $len = $$i - $start;
 
-      if ($s->[$start] == '-') {
+      if ($json_str->[$start] == '-') {
         switch ($len) {
           case 2: {
-            return -(                                                                                                      $s->[$start + 1] - '0' *     1);
+            return -(                                                                                                      $json_str->[$start + 1] - '0' *     1);
             break;
           }
           case 3: {
-            return -(                                                                              $s->[$start + 1] * 10 + $s->[$start + 2] - '0' *    11);
+            return -(                                                                              $json_str->[$start + 1] * 10 + $json_str->[$start + 2] - '0' *    11);
             break;
           }
           case 4: {
-            return -(                                                     $s->[$start + 1] * 100 + $s->[$start + 2] * 10 + $s->[$start + 3] - '0' *   111);
+            return -(                                                     $json_str->[$start + 1] * 100 + $json_str->[$start + 2] * 10 + $json_str->[$start + 3] - '0' *   111);
             break;
           }
           case 5: {
-            return -(                           $s->[$start + 1] * 1000 + $s->[$start + 2] * 100 + $s->[$start + 3] * 10 + $s->[$start + 4] - '0' *  1111);
+            return -(                           $json_str->[$start + 1] * 1000 + $json_str->[$start + 2] * 100 + $json_str->[$start + 3] * 10 + $json_str->[$start + 4] - '0' *  1111);
             break;
           }
           case 6: {
-            return -($s->[$start + 1] * 10000 + $s->[$start + 2] * 1000 + $s->[$start + 3] * 100 + $s->[$start + 4] * 10 + $s->[$start + 5] - '0' * 11111);
+            return -($json_str->[$start + 1] * 10000 + $json_str->[$start + 2] * 1000 + $json_str->[$start + 3] * 100 + $json_str->[$start + 4] * 10 + $json_str->[$start + 5] - '0' * 11111);
             break;
           }
         }
@@ -346,40 +346,40 @@ package SPVM::JSON {
       else {
         switch ($len) {
           case 1: {
-            return (                                                                                                           $s->[$start] - '0' *     1);
+            return (                                                                                                           $json_str->[$start] - '0' *     1);
             break;
           }
           case 2: {
-            return (                                                                                   $s->[$start] * 10 + $s->[$start + 1] - '0' *    11);
+            return (                                                                                   $json_str->[$start] * 10 + $json_str->[$start + 1] - '0' *    11);
             break;
           }
           case 3: {
-            return (                                                          $s->[$start] * 100 + $s->[$start + 1] * 10 + $s->[$start + 2] - '0' *   111);
+            return (                                                          $json_str->[$start] * 100 + $json_str->[$start + 1] * 10 + $json_str->[$start + 2] - '0' *   111);
             break;
           }
           case 4: {
-            return (                                $s->[$start] * 1000 + $s->[$start + 1] * 100 + $s->[$start + 2] * 10 + $s->[$start + 3] - '0' *  1111);
+            return (                                $json_str->[$start] * 1000 + $json_str->[$start + 1] * 100 + $json_str->[$start + 2] * 10 + $json_str->[$start + 3] - '0' *  1111);
             break;
           }
           case 5: {
-            return (     $s->[$start] * 10000 + $s->[$start + 1] * 1000 + $s->[$start + 2] * 100 + $s->[$start + 3] * 10 + $s->[$start + 4] - '0' * 11111);
+            return (     $json_str->[$start] * 10000 + $json_str->[$start + 1] * 1000 + $json_str->[$start + 2] * 100 + $json_str->[$start + 3] * 10 + $json_str->[$start + 4] - '0' * 11111);
             break;
           }
         }
       }
 
       my $grok_non_neg = sub : int ($self : self,
-          $s : string, $start : int, $len : int, $val : long&) {
+          $json_str : string, $start : int, $len : int, $val : long&) {
         my $number_type = 0;
         $$val = 0;
         for (my $i = 0; $i < $len; ++$i) {
           if ($$val <= (long)INT32_MAX()) {
-            $$val = $$val * 10 + $s->[$start + $i] - '0';
+            $$val = $$val * 10 + $json_str->[$start + $i] - '0';
           }
           elsif ($$val < INT64_MAX() / 10 ||
-              ($$val == INT64_MAX() / 10 && $s->[$start + $i] - '0' <= INT64_MAX() % 10)) {
+              ($$val == INT64_MAX() / 10 && $json_str->[$start + $i] - '0' <= INT64_MAX() % 10)) {
             $number_type = 1;
-            $$val = $$val * 10 + $s->[$start + $i] - '0';
+            $$val = $$val * 10 + $json_str->[$start + $i] - '0';
           }
           else {
             return -1;
@@ -389,18 +389,18 @@ package SPVM::JSON {
       };
 
       my $grok_neg = sub : int ($self : self,
-          $s : string, $start : int, $len : int, $val : long&) {
+          $json_str : string, $start : int, $len : int, $val : long&) {
         my $number_type = 0;
         $$val = 0;
         for (my $i = 0; $i < $len; ++$i) {
           if ($$val >= (long)INT32_MIN()) {
-            $$val = $$val * 10 - ($s->[$start + $i] - '0');
+            $$val = $$val * 10 - ($json_str->[$start + $i] - '0');
           }
           elsif ($$val > INT64_MIN() / 10 ||
               ($$val == INT64_MIN() / 10 &&
-                  $s->[$start + $i] - '0' <= -(INT64_MIN() + INT64_MIN() / 10 * 10))) {
+                  $json_str->[$start + $i] - '0' <= -(INT64_MIN() + INT64_MIN() / 10 * 10))) {
             $number_type = 1;
-            $$val = $$val * 10 - ($s->[$start + $i] - '0');
+            $$val = $$val * 10 - ($json_str->[$start + $i] - '0');
           }
           else {
             return -1;
@@ -412,8 +412,8 @@ package SPVM::JSON {
       my $val : long;
       my $number_type = 0;
 
-      if ($s->[$start] == '-') {
-        $number_type = $grok_neg->($s, $start + 1, $len - 1, \$val);
+      if ($json_str->[$start] == '-') {
+        $number_type = $grok_neg->($json_str, $start + 1, $len - 1, \$val);
         if ($number_type == 0) {
           return (int)$val;
         }
@@ -422,7 +422,7 @@ package SPVM::JSON {
         }
       }
       else {
-        $number_type = $grok_non_neg->($s, $start, $len, \$val);
+        $number_type = $grok_non_neg->($json_str, $start, $len, \$val);
         if ($number_type == 0) {
           return (int)$val;
         }
@@ -431,126 +431,126 @@ package SPVM::JSON {
         }
       }
 
-      if ($s->[$start] == '-') {
+      if ($json_str->[$start] == '-') {
         --$len;
       }
 
       # does not fit into long, try double
       if (DBL_DIG() >= $len) {
-        return _atof($s, $start, $end);
+        return _atof($json_str, $start, $end);
       }
 
       # everything else fails, convert it to a string
-      return substr($s, $start, $$i - $start);
+      return substr($json_str, $start, $$i - $start);
     }
 
     # loss of precision here
-    return _atof($s, $start, $end);
+    return _atof($json_str, $start, $end);
   }
 
-  sub _decode_true : SPVM::JSON::Bool ($self : self, $s : string, $i : int&, $end : int) {
-    _expect_token($s, $i, $end, "true");
+  sub _decode_true : SPVM::JSON::Bool ($self : self, $json_str : string, $i : int&, $end : int) {
+    _expect_token($json_str, $i, $end, "true");
     return SPVM::JSON::Bool->TRUE;
   }
 
-  sub _decode_false : SPVM::JSON::Bool ($self : self, $s : string, $i : int&, $end : int) {
-    _expect_token($s, $i, $end, "false");
+  sub _decode_false : SPVM::JSON::Bool ($self : self, $json_str : string, $i : int&, $end : int) {
+    _expect_token($json_str, $i, $end, "false");
     return SPVM::JSON::Bool->FALSE;
   }
 
-  sub _decode_hash : SPVM::Hash ($self : self, $s : string, $i : int&, $end : int) {
+  sub _decode_hash : SPVM::Hash ($self : self, $json_str : string, $i : int&, $end : int) {
     my $hash = SPVM::Hash->new;
     my $has_element = 0;
-    _expect_token($s, $i, $end, "{");
+    _expect_token($json_str, $i, $end, "{");
     while (1) {
       # end of hash
-      $self->_skip_spaces_at_not_end($s, $i, $end);
-      if ($s->[$$i] == '}') {
+      $self->_skip_spaces_at_not_end($json_str, $i, $end);
+      if ($json_str->[$$i] == '}') {
         last;
       }
 
       # comma
       if ($has_element) {
-        _expect_token($s, $i, $end, ",");
-        $self->_skip_spaces_at_not_end($s, $i, $end);
+        _expect_token($json_str, $i, $end, ",");
+        $self->_skip_spaces_at_not_end($json_str, $i, $end);
       }
       else {
         $has_element = 1;
       }
 
       # key
-      my $key = $self->_decode_string($s, $i, $end);
+      my $key = $self->_decode_string($json_str, $i, $end);
 
       # separator
-      $self->_skip_spaces_at_not_end($s, $i, $end);
-      _expect_token($s, $i, $end, ":");
+      $self->_skip_spaces_at_not_end($json_str, $i, $end);
+      _expect_token($json_str, $i, $end, ":");
 
       # value
-      $self->_skip_spaces_at_not_end($s, $i, $end);
-      $hash->set($key, $self->_decode_recursive($s, $i, $end));
+      $self->_skip_spaces_at_not_end($json_str, $i, $end);
+      $hash->set($key, $self->_decode_recursive($json_str, $i, $end));
     }
-    _expect_token($s, $i, $end, "}");
+    _expect_token($json_str, $i, $end, "}");
     return $hash;
   }
 
-  sub _decode_list : SPVM::ObjectList ($self : self, $s : string, $i : int&, $end : int) {
-    _expect_token($s, $i, $end, "[");
+  sub _decode_list : SPVM::ObjectList ($self : self, $json_str : string, $i : int&, $end : int) {
+    _expect_token($json_str, $i, $end, "[");
     my $list = SPVM::ObjectList->new;
     my $has_element = 0;
     while (1) {
       # end of list
-      $self->_skip_spaces_at_not_end($s, $i, $end);
-      if ($s->[$$i] == ']') {
+      $self->_skip_spaces_at_not_end($json_str, $i, $end);
+      if ($json_str->[$$i] == ']') {
         last;
       }
 
       # comma
       if ($has_element) {
-        _expect_token($s, $i, $end, ",");
-        $self->_skip_spaces_at_not_end($s, $i, $end);
+        _expect_token($json_str, $i, $end, ",");
+        $self->_skip_spaces_at_not_end($json_str, $i, $end);
       }
       else {
         $has_element = 1;
       }
-      $list->push($self->_decode_recursive($s, $i, $end));
+      $list->push($self->_decode_recursive($json_str, $i, $end));
     }
-    _expect_token($s, $i, $end, "]");
+    _expect_token($json_str, $i, $end, "]");
     return $list;
   }
 
-  sub _decode_recursive : object ($self : self, $s : string, $i : int&, $end : int) {
-    $self->_skip_spaces_at_not_end($s, $i, $end);
-    my $c = (int)($s->[$$i]);
+  sub _decode_recursive : object ($self : self, $json_str : string, $i : int&, $end : int) {
+    $self->_skip_spaces_at_not_end($json_str, $i, $end);
+    my $c = (int)($json_str->[$$i]);
     switch ($c) {
       case '{': {
         # objects
-        return $self->_decode_hash($s, $i, $end);
+        return $self->_decode_hash($json_str, $i, $end);
         break;
       }
       case '[': {
-        return $self->_decode_list($s, $i, $end);
+        return $self->_decode_list($json_str, $i, $end);
         break;
       }
       case '"': {
-        return $self->_decode_string($s, $i, $end);
+        return $self->_decode_string($json_str, $i, $end);
         break;
       }
       case '-': case 'i': case 'n':
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
-        return $self->_decode_num($s, $i, $end);
+        return $self->_decode_num($json_str, $i, $end);
         break;
       }
       case 't': {
-        return $self->_decode_true($s, $i, $end);
+        return $self->_decode_true($json_str, $i, $end);
         break;
       }
       case 'f': {
-        return $self->_decode_false($s, $i, $end);
+        return $self->_decode_false($json_str, $i, $end);
         break;
       }
       default: {
-        ERR("Unexpected token.", $s, $$i, $end);
+        ERR("Unexpected token.", $json_str, $$i, $end);
       }
     }
   }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -47,13 +47,6 @@ package SPVM::JSON {
     }
   }
 
-  precompile private sub _skip_spaces_at_not_end : void ($self : self, $json_str : string, $iter : int&, $end : int) {
-    $self->_skip_spaces($json_str, $iter, $end);
-    if ($$iter == $end) {
-      _custom_die("Incomplete JSON", $json_str, $$iter, $end);
-    }
-  }
-
   precompile private sub _expect_token : void ($json_str : string, $iter : int&, $end : int, $expected : string) {
     my $length = length $expected;
     unless ($$iter + $length <= $end) {
@@ -468,8 +461,12 @@ package SPVM::JSON {
     my $has_element = 0;
     _expect_token($json_str, $iter, $end, "{");
     while (1) {
+      $self->_skip_spaces($json_str, $iter, $end);
+      if ($$iter == $end) {
+        _custom_die("Incomplete object in JSON: end of string", $json_str, $$iter, $end);
+      }
+
       # end of hash
-      $self->_skip_spaces_at_not_end($json_str, $iter, $end);
       if ($json_str->[$$iter] == '}') {
         last;
       }
@@ -477,7 +474,7 @@ package SPVM::JSON {
       # comma
       if ($has_element) {
         _expect_token($json_str, $iter, $end, ",");
-        $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+        $self->_skip_spaces($json_str, $iter, $end);
       }
       else {
         $has_element = 1;
@@ -487,11 +484,11 @@ package SPVM::JSON {
       my $key = $self->_decode_string($json_str, $iter, $end);
 
       # separator
-      $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+      $self->_skip_spaces($json_str, $iter, $end);
       _expect_token($json_str, $iter, $end, ":");
 
       # value
-      $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+      $self->_skip_spaces($json_str, $iter, $end);
       $hash->set($key, $self->_decode_recursive($json_str, $iter, $end));
     }
     _expect_token($json_str, $iter, $end, "}");
@@ -503,8 +500,12 @@ package SPVM::JSON {
     my $list = SPVM::ObjectList->new;
     my $has_element = 0;
     while (1) {
+      $self->_skip_spaces($json_str, $iter, $end);
+      if ($$iter == $end) {
+        _custom_die("Incomplete array in JSON: end of string", $json_str, $$iter, $end);
+      }
+
       # end of list
-      $self->_skip_spaces_at_not_end($json_str, $iter, $end);
       if ($json_str->[$$iter] == ']') {
         last;
       }
@@ -512,7 +513,7 @@ package SPVM::JSON {
       # comma
       if ($has_element) {
         _expect_token($json_str, $iter, $end, ",");
-        $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+        $self->_skip_spaces($json_str, $iter, $end);
       }
       else {
         $has_element = 1;
@@ -524,7 +525,11 @@ package SPVM::JSON {
   }
 
   precompile private sub _decode_recursive : object ($self : self, $json_str : string, $iter : int&, $end : int) {
-    $self->_skip_spaces_at_not_end($json_str, $iter, $end);
+    $self->_skip_spaces($json_str, $iter, $end);
+    if ($$iter == $end) {
+      _custom_die("Incomplete JSON", $json_str, $$iter, $end);
+    }
+
     my $c = (int)($json_str->[$$iter]);
     switch ($c) {
       case '{': {

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -71,6 +71,15 @@ package SPVM::StringBuffer {
     $self->{length} += $length;
   }
 
+  sub push_char  : void ($self : self, $char : byte) {
+    my $capacity = @$self->{value};
+    if ($self->{length} + 1 > $capacity) {
+      my $new_capacity = $capacity * 2;
+      $self->_reallocate($new_capacity);
+    }
+    $self->{value}[$self->{length}++] = $char;
+  }
+
   sub to_str : string ($self : self) {
     return (string)(sliceb($self->{value}, 0, $self->{length}));
   }

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -80,6 +80,23 @@ package SPVM::StringBuffer {
     $self->{value}[$self->{length}++] = $char;
   }
 
+  sub push_range  : void ($self : self, $string : string, $offset : int, $length : int) {
+    my $capacity = @$self->{value};
+    if ($self->{length} + $length > $capacity) {
+      my $new_capacity : int;
+      if ($self->{length} + $length > $capacity * 2) {
+        $new_capacity = $self->{length} + $length;
+      } else {
+        $new_capacity = $capacity * 2;
+      }
+      $self->_reallocate($new_capacity);
+    }
+    for (my $i = 0; $i < $length; ++$i) {
+      $self->{value}[$self->{length} + $i] = $string->[$offset + $i];
+    }
+    $self->{length} += $length;
+  }
+
   sub to_str : string ($self : self) {
     return (string)(sliceb($self->{value}, 0, $self->{length}));
   }

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -64,17 +64,11 @@ package SPVM::StringBuffer {
         $new_capacity = $capacity * 2;
       }
       $self->_reallocate($new_capacity);
-      for (my $i = 0; $i < $length; ++$i) {
-        $self->{value}[$self->{length} + $i] = $string->[$i];
-      }
-      $self->{length} += $length;
     }
-    else {
-      for (my $i = 0; $i < $length; ++$i) {
-        $self->{value}[$self->{length} + $i] = $string->[$i];
-      }
-      $self->{length} += $length;
+    for (my $i = 0; $i < $length; ++$i) {
+      $self->{value}[$self->{length} + $i] = $string->[$i];
     }
+    $self->{length} += $length;
   }
 
   sub to_str : string ($self : self) {

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -11,7 +11,8 @@ package SPVM::StringBuffer {
   sub capacity : int ($self : self) {
     return @$self->{value};
   }
-  
+
+  # O($new_capacity)
   private sub _reallocate : void ($self : self, $new_capacity : int) {
     my $new_string = new byte [$new_capacity];
     for (my $i = 0; $i < $self->{length}; ++$i) {
@@ -56,7 +57,6 @@ package SPVM::StringBuffer {
     my $length = length($string);
     my $capacity = @$self->{value};
     if ($self->{length} + $length > $capacity) {
-      # O($new_capacity)
       my $new_capacity : int;
       if ($self->{length} + $length > $capacity * 2) {
         $new_capacity = $self->{length} + $length;

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -441,6 +441,26 @@ package TestCase::JSON {
     return 1;
   }
 
+  sub encode_string : int () {
+    my $input = "str";
+    my $got = $DEFAULT_JSON->encode($input);
+    my $expected = "\"str\"";
+    unless ($got eq $expected) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub decode_string : int () {
+    my $input = "\"str\"";
+    my $got = $DEFAULT_JSON->decode($input);
+    my $expected = "str";
+    unless (_equals($got, $expected)) {
+      return 0;
+    }
+    return 1;
+  }
+
   sub test_root_is_primitive : int () {
     my $tests = ["\"abc\"", "123", "true"];
     return _validate($DEFAULT_JSON, $tests, $tests);

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -461,11 +461,6 @@ package TestCase::JSON {
     return 1;
   }
 
-  sub test_root_is_primitive : int () {
-    my $tests = ["\"abc\"", "123", "true"];
-    return _validate($DEFAULT_JSON, $tests, $tests);
-  }
-
   sub test_nest_object : int () {
     my $tests = [
       "{\"A\":{\"B\":1,\"C\":{\"D\":0.1,\"E\":true,\"F\":\"str\",\"G\":[\"elem\",\"ents\",{\"key\":\"value\"}]}},\"end\":\"eof\"}"

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -644,12 +644,19 @@ package TestCase::JSON {
     return 1;
   }
 
-  sub test_map_inf_nan_to_undef : int () {
-    my $inputs = ["inf", "-inf", "nan"];
-    for (my $i = 0; $i < @$inputs; ++$i) {
-      unless ($DEFAULT_JSON->decode($inputs->[$i]) == undef) {
-        return 0;
-      }
+  sub decode_inf : int () {
+    unless ($DEFAULT_JSON->decode("inf") == undef) {
+      return 0;
+    }
+    unless ($DEFAULT_JSON->decode("-inf") == undef) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub decode_nan : int () {
+    unless ($DEFAULT_JSON->decode("nan") == undef) {
+      return 0;
     }
     return 1;
   }

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -137,9 +137,134 @@ package TestCase::JSON {
     return 1;
   }
 
-  sub test_flat_hash : int () {
-    my $tests = ["{}", "{\"digit\":42}", "{\"string\":\"vstr\"}", "{\"double\":0.123}", "{\"bool_true\":true}", "{\"bool_false\":false}", "{\"A\":0.1,\"ABC\":false,\"a\":1,\"qwerty\":\"asdfg\"}"];
-    return _validate($DEFAULT_JSON, $tests, $tests);
+  sub encode_flat_hash : int () {
+    {
+      my $input    = SPVM::Hash->new;
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "{}";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input    = SPVM::Hash->newa([(object) "int" => 42 ]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "{\"int\":42}";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input    = SPVM::Hash->newa([(object) "string" => "vstr" ]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "{\"string\":\"vstr\"}";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input    = SPVM::Hash->newa([(object) "double" => 0.123 ]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "{\"double\":0.123}";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input    = SPVM::Hash->newa([(object) "bool_true" => SPVM::JSON::Bool->TRUE]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "{\"bool_true\":true}";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input    = SPVM::Hash->newa([(object) "bool_false" => SPVM::JSON::Bool->FALSE]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "{\"bool_false\":false}";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input    = SPVM::Hash->newa([(object)
+        "bool"   => SPVM::JSON::Bool->FALSE,
+        "double" => 0.1,
+        "int"    => 1,
+        "str"    => "hoge",
+      ]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "{\"bool\":false,\"double\":0.1,\"int\":1,\"str\":\"hoge\"}";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    return 1;
+  }
+
+  sub decode_flat_hash : int () {
+    {
+      my $input    = "{}";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::Hash->new;
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = "{\"int\":42}";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::Hash->newa([(object) "int" => 42 ]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = "{\"string\":\"vstr\"}";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::Hash->newa([(object) "string" => "vstr" ]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = "{\"double\":0.123}";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::Hash->newa([(object) "double" => 0.123 ]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = "{\"bool_true\":true}";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::Hash->newa([(object) "bool_true" => SPVM::JSON::Bool->TRUE]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = "{\"bool_false\":false}";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::Hash->newa([(object) "bool_false" => SPVM::JSON::Bool->FALSE]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = "{\"double\":0.1,\"bool\":false,\"int\":1,\"str\":\"hoge\"}";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::Hash->newa([(object)
+        "bool"   => SPVM::JSON::Bool->FALSE,
+        "double" => 0.1,
+        "int"    => 1,
+        "str"    => "hoge",
+      ]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    return 1;
   }
 
   sub test_flat_list : int () {

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -267,9 +267,76 @@ package TestCase::JSON {
     return 1;
   }
 
-  sub test_flat_list : int () {
-    my $tests = ["[]", "[1,2,3]", "[\"abc\",\"123\"]", "[123,\"abc\",0,\"123abc\",3.1415]"];
-    return _validate($DEFAULT_JSON, $tests, $tests);
+  sub encode_flat_list : int () {
+    {
+      my $input    = SPVM::ObjectList->new;
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "[]";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input    = SPVM::ObjectList->newa([(object) 1, 2, 3]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "[1,2,3]";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input    = SPVM::ObjectList->newa([(object) "abc", "def"]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "[\"abc\",\"def\"]";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input    = SPVM::ObjectList->newa([(object) 0, 3.14, "abc", SPVM::JSON::Bool->TRUE]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "[0,3.14,\"abc\",true]";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    return 1;
+  }
+
+  sub decode_flat_list : int () {
+    {
+      my $input    = "[]";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::ObjectList->new;
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = "[3,2,1]";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::ObjectList->newa([(object) 3, 2, 1]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = "[\"def\",\"abc\"]";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::ObjectList->newa([(object) "def", "abc"]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = "[0,3.14,\"abc\",true]";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::ObjectList->newa([(object) 0, 3.14, "abc", SPVM::JSON::Bool->TRUE]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    return 1;
   }
 
   sub test_digits_int : int () {

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -264,6 +264,17 @@ package TestCase::JSON {
         return 0;
       }
     }
+    {
+      my $input    = " { \"key\" \n\t: 123\t,\n\t\t\"list\" :\n[\t1\t,\r2\t,\t3\n]}\r\r";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::Hash->newa([(object)
+        "key"  => 123,
+        "list" => SPVM::ObjectList->newa([(object) 1, 2, 3])
+      ]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
     return 1;
   }
 
@@ -332,6 +343,14 @@ package TestCase::JSON {
       my $input    = "[0,3.14,\"abc\",true]";
       my $got      = $DEFAULT_JSON->decode($input);
       my $expected = SPVM::ObjectList->newa([(object) 0, 3.14, "abc", SPVM::JSON::Bool->TRUE]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input    = " [ 1, 3.14\n, true \t , \"a\" ] ";
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::ObjectList->newa([(object) 1, 3.14, SPVM::JSON::Bool->TRUE, "a"]);
       unless (_equals($got, $expected)) {
         return 0;
       }
@@ -513,20 +532,6 @@ package TestCase::JSON {
       return 0;
     }
     return 1;
-  }
-
-  sub test_spaces : int () {
-    my $inputs = [
-      # Root type is "hash"
-      " { \"key\" \n\t: 123\t,\n\t\t\"list\" :\n[\t1\t,\r2\t,\t3\n]}\r\r",
-      # Root type is "list"
-      " [ 1, 3.14\n, true \t , \"a\" ] " # primitives: Int, Double, Bool, string
-    ];
-    my $outputs = [
-      "{\"key\":123,\"list\":[1,2,3]}",
-      "[1,3.14,true,\"a\"]"
-    ];
-    return _validate($DEFAULT_JSON, $inputs, $outputs);
   }
 
   sub test_format_name_separator : int () {

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -367,24 +367,34 @@ package TestCase::JSON {
     return 1;
   }
 
-  sub test_digits_double : int () {
-    my $input = [
-      "0.123", "-0.123", "3.14", "-3.14", "123.987", "-123.987",
-      "1.23456e+1", "1.23456e-1", "1.23456e+08", "1.23456e-08", "1.23456e+008", "1.23456e-008",
-      "1.23456e+018", "1.23456e-018", "9.9e-100", "9.9e+300", "-1.23e+123"
-    ];
-    my $expected = [
+  sub encode_double : int () {
+    my $test_case  = [
       0.123, -0.123, 3.14, -3.14, 123.987, -123.987,
       1.23456e+1, 1.23456e-1, 1.23456e+08, 1.23456e-08, 1.23456e+008, 1.23456e-008,
       1.23456e+018, 1.23456e-018, 9.9e-100, 9.9e+300, -1.23e+123
     ];
-    for (my $i = 0; $i < @$input; $i++) {
-      my $got = (SPVM::Double)($DEFAULT_JSON->decode($input->[$i]));
-      unless (("" . $got->val) eq ("" . $expected->[$i])) {
+    for (my $i = 0; $i < @$test_case; ++$i) {
+      my $input    = SPVM::Double->new($test_case->[$i]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = "" . $test_case->[$i];
+      unless ($got eq $expected) {
         return 0;
       }
-      my $re_got = (SPVM::Double)($DEFAULT_JSON->decode($DEFAULT_JSON->encode($got)));
-      unless (("" . $re_got->val) eq ("" . $expected->[$i])) {
+    }
+    return 1;
+  }
+
+  sub decode_double : int () {
+    my $test_case  = [
+      0.123, -0.123, 3.14, -3.14, 123.987, -123.987,
+      1.23456e+1, 1.23456e-1, 1.23456e+08, 1.23456e-08, 1.23456e+008, 1.23456e-008,
+      1.23456e+018, 1.23456e-018, 9.9e-100, 9.9e+300, -1.23e+123
+    ];
+    for (my $i = 0; $i < @$test_case; ++$i) {
+      my $input    = "" . $test_case->[$i];
+      my $got      = "" . ((SPVM::Double)$DEFAULT_JSON->decode($input))->val;
+      my $expected = "" . $test_case->[$i];
+      unless ($got eq $expected) {
         return 0;
       }
     }

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -401,6 +401,46 @@ package TestCase::JSON {
     return 1;
   }
 
+  sub encode_bool : int () {
+    {
+      my $input = SPVM::JSON::Bool->TRUE;
+      my $got = $DEFAULT_JSON->encode($input);
+      my $expected = "true";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    {
+      my $input = SPVM::JSON::Bool->FALSE;
+      my $got = $DEFAULT_JSON->encode($input);
+      my $expected = "false";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    return 1;
+  }
+
+  sub decode_bool : int () {
+    {
+      my $input = "true";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::JSON::Bool->TRUE;
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    {
+      my $input = "false";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::JSON::Bool->FALSE;
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    return 1;
+  }
+
   sub test_root_is_primitive : int () {
     my $tests = ["\"abc\"", "123", "true"];
     return _validate($DEFAULT_JSON, $tests, $tests);

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -461,11 +461,55 @@ package TestCase::JSON {
     return 1;
   }
 
-  sub test_nest_object : int () {
-    my $tests = [
-      "{\"A\":{\"B\":1,\"C\":{\"D\":0.1,\"E\":true,\"F\":\"str\",\"G\":[\"elem\",\"ents\",{\"key\":\"value\"}]}},\"end\":\"eof\"}"
-    ];
-    unless (_validate($DEFAULT_JSON, $tests, $tests)) {
+  sub encode_nested_hash : int () {
+    my $input = SPVM::Hash->newa([(object)
+      "A" => SPVM::Hash->newa([(object)
+        "B" => 1,
+        "C" => SPVM::Hash->newa([(object)
+          "D" => 0.1,
+          "E" => SPVM::JSON::Bool->TRUE,
+          "F" => "str",
+          "G" => SPVM::ObjectList->newa([(object)
+            "abc",
+            123,
+            SPVM::Hash->newa([(object)
+              "H" => "val",
+            ]),
+          ]),
+        ])
+      ]),
+      "I" => "EOF",
+    ]);
+    my $got = $DEFAULT_JSON->encode($input);
+    my $expected = "{\"A\":{\"B\":1,\"C\":{\"D\":0.1,\"E\":true,\"F\":\"str\",\"G\":[\"abc\",123,{\"H\":\"val\"}]}},\"I\":\"EOF\"}";
+    unless ($got eq $expected) {
+      return 0;
+    }
+    return 1;
+  }
+
+  sub decode_nested_hash : int () {
+    my $input = "{\"A\":{\"B\":1,\"C\":{\"D\":0.1,\"E\":true,\"F\":\"str\",\"G\":[\"abc\",123,{\"H\":\"val\"}]}},\"I\":\"EOF\"}";
+    my $got = $DEFAULT_JSON->decode($input);
+    my $expected = SPVM::Hash->newa([(object)
+      "A" => SPVM::Hash->newa([(object)
+        "B" => 1,
+        "C" => SPVM::Hash->newa([(object)
+          "D" => 0.1,
+          "E" => SPVM::JSON::Bool->TRUE,
+          "F" => "str",
+          "G" => SPVM::ObjectList->newa([(object)
+            "abc",
+            123,
+            SPVM::Hash->newa([(object)
+              "H" => "val",
+            ]),
+          ]),
+        ])
+      ]),
+      "I" => "EOF",
+    ]);
+    unless (_equals($got, $expected)) {
       return 0;
     }
     return 1;

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -339,9 +339,32 @@ package TestCase::JSON {
     return 1;
   }
 
-  sub test_digits_int : int () {
-    my $tests = ["[0,1,-1]"];
-    return _validate($DEFAULT_JSON, $tests, $tests);
+  sub encode_int : int () {
+    my $test_case_json = ["-1", "0", "1"];
+    my $test_case_int  = [-1, 0, 1];
+    for (my $i = 0; $i < @$test_case_json; ++$i) {
+      my $input    = SPVM::Int->new($test_case_int->[$i]);
+      my $got      = $DEFAULT_JSON->encode($input);
+      my $expected = $test_case_json->[$i];
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    return 1;
+  }
+
+  sub decode_int : int () {
+    my $test_case_json = ["-1", "0", "1"];
+    my $test_case_int  = [-1, 0, 1];
+    for (my $i = 0; $i < @$test_case_json; ++$i) {
+      my $input    = $test_case_json->[$i];
+      my $got      = $DEFAULT_JSON->decode($input);
+      my $expected = SPVM::Int->new($test_case_int->[$i]);
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    return 1;
   }
 
   sub test_digits_double : int () {

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -4,12 +4,125 @@ package TestCase::JSON {
   use SPVM::Int;
   use SPVM::Double;
   use SPVM::JSON::Bool;
+  use SPVM::Hash;
+  use SPVM::Sort (sortstr);
 
   our $DEFAULT_JSON : SPVM::JSON;
 
   BEGIN {
     $DEFAULT_JSON = SPVM::JSON->new;
     $DEFAULT_JSON->set_canonical(1);
+  }
+
+  sub _equals : int ($lhs : object, $rhs : object) {
+    if ($lhs == undef) {
+      unless ($rhs == undef) {
+        return 0;
+      }
+    }
+    elsif ($lhs isa SPVM::Hash) {
+      unless ($rhs isa SPVM::Hash) {
+        return 0;
+      }
+
+      my $l_hash = (SPVM::Hash)$lhs;
+      my $r_hash = (SPVM::Hash)$lhs;
+
+      my $l_keys = $l_hash->keys;
+      my $r_keys = $r_hash->keys;
+
+      if (@$l_keys == 0) {
+        unless (@$r_keys == 0) {
+          return 0;
+        }
+      }
+      else {
+        sortstr($l_keys);
+        sortstr($r_keys);
+
+        for (my $key_index = 0; $key_index < @$l_keys; ++$key_index) {
+          my $key = $l_keys->[$key_index];
+          unless ($l_keys->[$key_index] eq $r_keys->[$key_index]) {
+            return 0;
+          }
+          unless (_equals($l_hash->get($key), $r_hash->get($key))) {
+            return 0;
+          }
+        }
+      }
+    }
+    elsif ($lhs isa SPVM::ObjectList) {
+      unless ($rhs isa SPVM::ObjectList) {
+        return 0;
+      }
+
+      my $l_list = (SPVM::ObjectList)$lhs;
+      my $r_list = (SPVM::ObjectList)$rhs;
+
+      unless ($l_list->length == $r_list->length) {
+        return 0;
+      }
+
+      my $length = $l_list->length;
+      for (my $list_index = 0; $list_index < $length; ++$list_index) {
+        unless (_equals($l_list->get($list_index), $r_list->get($list_index))) {
+          return 0;
+        }
+      }
+    }
+    elsif ($lhs isa string) {
+      unless ($rhs isa string) {
+        return 0;
+      }
+
+      my $l_str = (string)$lhs;
+      my $r_str = (string)$rhs;
+
+      unless ($l_str eq $r_str) {
+        return 0;
+      }
+    }
+    elsif ($lhs isa SPVM::Int) {
+      unless ($rhs isa SPVM::Int) {
+        return 0;
+      }
+
+      my $l_int = (SPVM::Int)$lhs;
+      my $r_int = (SPVM::Int)$rhs;
+
+      unless ($l_int->val == $r_int->val) {
+        return 0;
+      }
+    }
+    elsif ($lhs isa SPVM::JSON::Bool) {
+      unless ($rhs isa SPVM::JSON::Bool) {
+        return 0;
+      }
+
+      my $l_bool = (SPVM::JSON::Bool)$lhs;
+      my $r_bool = (SPVM::JSON::Bool)$rhs;
+
+      unless ($l_bool->val == $r_bool->val) {
+        return 0;
+      }
+    }
+    elsif ($lhs isa SPVM::Double) {
+      unless ($rhs isa SPVM::Double) {
+        return 0;
+      }
+
+      my $l_dbl = (SPVM::Double)$lhs;
+      my $r_dbl = (SPVM::Double)$rhs;
+
+      unless ($l_dbl->val == $r_dbl->val) {
+        return 0;
+      }
+    }
+    else {
+      die "Not implemented type is used in \$lhs";
+    }
+
+    return 1;
   }
 
   sub _validate : int ($json : SPVM::JSON, $input : string[], $expected : string[]) {

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -534,15 +534,6 @@ package TestCase::JSON {
     return 1;
   }
 
-  sub test_format_name_separator : int () {
-    my $hash = SPVM::Hash->newa([(object) "key", "value"]);
-    my $json = SPVM::JSON->new;
-    unless ($json->encode($hash) eq "{\"key\":\"value\"}") {
-      return 0;
-    }
-    return 1;
-  }
-
   sub test_special_chars : int () {
     my $tests = ["\"\\\"\\\\\\t\\n\\r\""];
     unless (_validate($DEFAULT_JSON, $tests, $tests)) {

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -461,21 +461,117 @@ package TestCase::JSON {
   }
 
   sub encode_string : int () {
-    my $input = "str";
-    my $got = $DEFAULT_JSON->encode($input);
-    my $expected = "\"str\"";
-    unless ($got eq $expected) {
-      return 0;
+    {
+      my $input = "str";
+      my $got = $DEFAULT_JSON->encode($input);
+      my $expected = "\"str\"";
+      unless ($got eq $expected) {
+        return 0;
+      }
+    }
+    # special characters
+    # '\'
+    {
+      my $input = "\\";
+      my $got = $DEFAULT_JSON->encode($input);
+      my $expected = "\"\\\\\"";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '"'
+    {
+      my $input = "\"";
+      my $got = $DEFAULT_JSON->encode($input);
+      my $expected = "\"\\\"\"";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '\t'
+    {
+      my $input = "\t";
+      my $got = $DEFAULT_JSON->encode($input);
+      my $expected = "\"\\t\"";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '\n'
+    {
+      my $input = "\n";
+      my $got = $DEFAULT_JSON->encode($input);
+      my $expected = "\"\\n\"";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '\r'
+    {
+      my $input = "\r";
+      my $got = $DEFAULT_JSON->encode($input);
+      my $expected = "\"\\r\"";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
     }
     return 1;
   }
 
   sub decode_string : int () {
-    my $input = "\"str\"";
-    my $got = $DEFAULT_JSON->decode($input);
-    my $expected = "str";
-    unless (_equals($got, $expected)) {
-      return 0;
+    {
+      my $input = "\"str\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "str";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # special characters
+    # '\'
+    {
+      my $input = "\"\\\\\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "\\";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '"'
+    {
+      my $input = "\"\\\"\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "\"";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '\t'
+    {
+      my $input = "\"\\t\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "\t";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '\n'
+    {
+      my $input = "\"\\n\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "\n";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '\r'
+    {
+      my $input = "\"\\r\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "\r";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
     }
     return 1;
   }
@@ -529,14 +625,6 @@ package TestCase::JSON {
       "I" => "EOF",
     ]);
     unless (_equals($got, $expected)) {
-      return 0;
-    }
-    return 1;
-  }
-
-  sub test_special_chars : int () {
-    my $tests = ["\"\\\"\\\\\\t\\n\\r\""];
-    unless (_validate($DEFAULT_JSON, $tests, $tests)) {
       return 0;
     }
     return 1;

--- a/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
@@ -132,6 +132,26 @@ package TestCase::Lib::SPVM::StringBuffer {
     return 1;
   }
 
+  sub test_push_char  : int () {
+    my $buffer = SPVM::StringBuffer->new_opt([(object)capacity => 1]);
+    $buffer->push_char('a');
+    unless ($buffer->to_str eq "a" && $buffer->capacity == 1) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->push_char('b');
+    unless ($buffer->to_str eq "ab" && $buffer->capacity == 2) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->push_char('c');
+    unless ($buffer->to_str eq "abc" && $buffer->capacity == 4) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    return 1;
+  }
+
   sub test_append_copy_on_write : int () {
     warn("TODO: append copy-on-write test is not implemented yet");
     return 0;

--- a/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
@@ -152,6 +152,27 @@ package TestCase::Lib::SPVM::StringBuffer {
     return 1;
   }
 
+  sub test_push_range  : int () {
+    my $buffer = SPVM::StringBuffer->new_opt([(object)capacity => 1]);
+    my $string = "abcde";
+    $buffer->push_range($string, 0, 3);
+    unless ($buffer->to_str eq "abc" && $buffer->capacity == 3) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->push_range($string, 1, 3);
+    unless ($buffer->to_str eq "abcbcd" && $buffer->capacity == 6) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->push_range($string, 2, 3);
+    unless ($buffer->to_str eq "abcbcdcde" && $buffer->capacity == 12) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    return 1;
+  }
+
   sub test_append_copy_on_write : int () {
     warn("TODO: append copy-on-write test is not implemented yet");
     return 0;

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -21,7 +21,6 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_bool);
   ok(TestCase::JSON->encode_string);
   ok(TestCase::JSON->encode_nested_hash);
-  ok(TestCase::JSON->test_format_name_separator);
   ok(TestCase::JSON->test_special_chars);
   ok(TestCase::JSON->test_map_inf_nan_to_undef);
 }

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -14,7 +14,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 # encode
 {
   ok(TestCase::JSON->encode_null);
-  ok(TestCase::JSON->test_flat_hash);
+  ok(TestCase::JSON->encode_flat_hash);
   ok(TestCase::JSON->test_flat_list);
   ok(TestCase::JSON->test_digits_int);
   ok(TestCase::JSON->test_digits_double);
@@ -29,6 +29,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 # decode
 {
   ok(TestCase::JSON->decode_null);
+  ok(TestCase::JSON->decode_flat_hash);
 }
 
 # All object is freed

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -21,7 +21,6 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_bool);
   ok(TestCase::JSON->encode_string);
   ok(TestCase::JSON->encode_nested_hash);
-  ok(TestCase::JSON->test_spaces);
   ok(TestCase::JSON->test_format_name_separator);
   ok(TestCase::JSON->test_special_chars);
   ok(TestCase::JSON->test_map_inf_nan_to_undef);

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -15,7 +15,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 {
   ok(TestCase::JSON->encode_null);
   ok(TestCase::JSON->encode_flat_hash);
-  ok(TestCase::JSON->test_flat_list);
+  ok(TestCase::JSON->encode_flat_list);
   ok(TestCase::JSON->test_digits_int);
   ok(TestCase::JSON->test_digits_double);
   ok(TestCase::JSON->test_root_is_primitive);
@@ -30,6 +30,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 {
   ok(TestCase::JSON->decode_null);
   ok(TestCase::JSON->decode_flat_hash);
+  ok(TestCase::JSON->decode_flat_list);
 }
 
 # All object is freed

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -21,12 +21,13 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_bool);
   ok(TestCase::JSON->encode_string);
   ok(TestCase::JSON->encode_nested_hash);
-  ok(TestCase::JSON->test_map_inf_nan_to_undef);
 }
 
 # decode
 {
   ok(TestCase::JSON->decode_null);
+  ok(TestCase::JSON->decode_inf);
+  ok(TestCase::JSON->decode_nan);
   ok(TestCase::JSON->decode_flat_hash);
   ok(TestCase::JSON->decode_flat_list);
   ok(TestCase::JSON->decode_int);

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -18,6 +18,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_flat_list);
   ok(TestCase::JSON->encode_int);
   ok(TestCase::JSON->encode_double);
+  ok(TestCase::JSON->encode_bool);
   ok(TestCase::JSON->test_root_is_primitive);
   ok(TestCase::JSON->test_nest_object);
   ok(TestCase::JSON->test_spaces);
@@ -33,6 +34,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->decode_flat_list);
   ok(TestCase::JSON->decode_int);
   ok(TestCase::JSON->decode_double);
+  ok(TestCase::JSON->decode_bool);
 }
 
 # All object is freed

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -21,7 +21,6 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_bool);
   ok(TestCase::JSON->encode_string);
   ok(TestCase::JSON->encode_nested_hash);
-  ok(TestCase::JSON->test_special_chars);
   ok(TestCase::JSON->test_map_inf_nan_to_undef);
 }
 

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -19,6 +19,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_int);
   ok(TestCase::JSON->encode_double);
   ok(TestCase::JSON->encode_bool);
+  ok(TestCase::JSON->encode_string);
   ok(TestCase::JSON->test_root_is_primitive);
   ok(TestCase::JSON->test_nest_object);
   ok(TestCase::JSON->test_spaces);
@@ -35,6 +36,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->decode_int);
   ok(TestCase::JSON->decode_double);
   ok(TestCase::JSON->decode_bool);
+  ok(TestCase::JSON->decode_string);
 }
 
 # All object is freed

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -20,7 +20,6 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_double);
   ok(TestCase::JSON->encode_bool);
   ok(TestCase::JSON->encode_string);
-  ok(TestCase::JSON->test_root_is_primitive);
   ok(TestCase::JSON->test_nest_object);
   ok(TestCase::JSON->test_spaces);
   ok(TestCase::JSON->test_format_name_separator);

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -17,7 +17,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_flat_hash);
   ok(TestCase::JSON->encode_flat_list);
   ok(TestCase::JSON->encode_int);
-  ok(TestCase::JSON->test_digits_double);
+  ok(TestCase::JSON->encode_double);
   ok(TestCase::JSON->test_root_is_primitive);
   ok(TestCase::JSON->test_nest_object);
   ok(TestCase::JSON->test_spaces);
@@ -32,6 +32,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->decode_flat_hash);
   ok(TestCase::JSON->decode_flat_list);
   ok(TestCase::JSON->decode_int);
+  ok(TestCase::JSON->decode_double);
 }
 
 # All object is freed

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -16,7 +16,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_null);
   ok(TestCase::JSON->encode_flat_hash);
   ok(TestCase::JSON->encode_flat_list);
-  ok(TestCase::JSON->test_digits_int);
+  ok(TestCase::JSON->encode_int);
   ok(TestCase::JSON->test_digits_double);
   ok(TestCase::JSON->test_root_is_primitive);
   ok(TestCase::JSON->test_nest_object);
@@ -31,6 +31,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->decode_null);
   ok(TestCase::JSON->decode_flat_hash);
   ok(TestCase::JSON->decode_flat_list);
+  ok(TestCase::JSON->decode_int);
 }
 
 # All object is freed

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -20,7 +20,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->encode_double);
   ok(TestCase::JSON->encode_bool);
   ok(TestCase::JSON->encode_string);
-  ok(TestCase::JSON->test_nest_object);
+  ok(TestCase::JSON->encode_nested_hash);
   ok(TestCase::JSON->test_spaces);
   ok(TestCase::JSON->test_format_name_separator);
   ok(TestCase::JSON->test_special_chars);
@@ -36,6 +36,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::JSON->decode_double);
   ok(TestCase::JSON->decode_bool);
   ok(TestCase::JSON->decode_string);
+  ok(TestCase::JSON->decode_nested_hash);
 }
 
 # All object is freed

--- a/t/default/modules/SPVM-StringBuffer.t
+++ b/t/default/modules/SPVM-StringBuffer.t
@@ -19,6 +19,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::Lib::SPVM::StringBuffer->test_substr);
   ok(TestCase::Lib::SPVM::StringBuffer->test_push);
   ok(TestCase::Lib::SPVM::StringBuffer->test_push_char);
+  ok(TestCase::Lib::SPVM::StringBuffer->test_push_range);
   ok(TestCase::Lib::SPVM::StringBuffer->test_to_str);
   ok(TestCase::Lib::SPVM::StringBuffer->test_index);
 }

--- a/t/default/modules/SPVM-StringBuffer.t
+++ b/t/default/modules/SPVM-StringBuffer.t
@@ -18,6 +18,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::Lib::SPVM::StringBuffer->test_length);
   ok(TestCase::Lib::SPVM::StringBuffer->test_substr);
   ok(TestCase::Lib::SPVM::StringBuffer->test_push);
+  ok(TestCase::Lib::SPVM::StringBuffer->test_push_char);
   ok(TestCase::Lib::SPVM::StringBuffer->test_to_str);
   ok(TestCase::Lib::SPVM::StringBuffer->test_index);
 }


### PR DESCRIPTION
https://github.com/yuki-kimoto/SPVM/issues/129

- [x] 解析するJSONテキストの長さ
- [x] 文字列の動的リスト
- [x] SPVM::StringBufferへ、push_range, push_charを追加 (#131)
- [x] decode関数の実装 (一部)
- [x] _skip_spacesだけにする
- [x] 引数渡しの$sと$iに長い名前をつける
- [x] ERRは通常のメソッドなので小文字でOK
- [x] プライベートなメソッドにprivateを追加
- [x] すべてのメソッドにprecompileを追加
- [x] 試験のリファクタリング
- [x] $grok_negを普通のサブルーチンへ