### PR TITLE
Add push methods in string buffer

### DIFF
--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -71,6 +71,15 @@ package SPVM::StringBuffer {
     $self->{length} += $length;
   }
 
+  sub push_char  : void ($self : self, $char : byte) {
+    my $capacity = @$self->{value};
+    if ($self->{length} + 1 > $capacity) {
+      my $new_capacity = $capacity * 2;
+      $self->_reallocate($new_capacity);
+    }
+    $self->{value}[$self->{length}++] = $char;
+  }
+
   sub to_str : string ($self : self) {
     return (string)(sliceb($self->{value}, 0, $self->{length}));
   }

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -80,6 +80,23 @@ package SPVM::StringBuffer {
     $self->{value}[$self->{length}++] = $char;
   }
 
+  sub push_range  : void ($self : self, $string : string, $offset : int, $length : int) {
+    my $capacity = @$self->{value};
+    if ($self->{length} + $length > $capacity) {
+      my $new_capacity : int;
+      if ($self->{length} + $length > $capacity * 2) {
+        $new_capacity = $self->{length} + $length;
+      } else {
+        $new_capacity = $capacity * 2;
+      }
+      $self->_reallocate($new_capacity);
+    }
+    for (my $i = 0; $i < $length; ++$i) {
+      $self->{value}[$self->{length} + $i] = $string->[$offset + $i];
+    }
+    $self->{length} += $length;
+  }
+
   sub to_str : string ($self : self) {
     return (string)(sliceb($self->{value}, 0, $self->{length}));
   }

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -64,17 +64,11 @@ package SPVM::StringBuffer {
         $new_capacity = $capacity * 2;
       }
       $self->_reallocate($new_capacity);
-      for (my $i = 0; $i < $length; ++$i) {
-        $self->{value}[$self->{length} + $i] = $string->[$i];
-      }
-      $self->{length} += $length;
     }
-    else {
-      for (my $i = 0; $i < $length; ++$i) {
-        $self->{value}[$self->{length} + $i] = $string->[$i];
-      }
-      $self->{length} += $length;
+    for (my $i = 0; $i < $length; ++$i) {
+      $self->{value}[$self->{length} + $i] = $string->[$i];
     }
+    $self->{length} += $length;
   }
 
   sub to_str : string ($self : self) {

--- a/lib/SPVM/StringBuffer.spvm
+++ b/lib/SPVM/StringBuffer.spvm
@@ -11,7 +11,8 @@ package SPVM::StringBuffer {
   sub capacity : int ($self : self) {
     return @$self->{value};
   }
-  
+
+  # O($new_capacity)
   private sub _reallocate : void ($self : self, $new_capacity : int) {
     my $new_string = new byte [$new_capacity];
     for (my $i = 0; $i < $self->{length}; ++$i) {
@@ -56,7 +57,6 @@ package SPVM::StringBuffer {
     my $length = length($string);
     my $capacity = @$self->{value};
     if ($self->{length} + $length > $capacity) {
-      # O($new_capacity)
       my $new_capacity : int;
       if ($self->{length} + $length > $capacity * 2) {
         $new_capacity = $self->{length} + $length;

--- a/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
@@ -132,6 +132,26 @@ package TestCase::Lib::SPVM::StringBuffer {
     return 1;
   }
 
+  sub test_push_char  : int () {
+    my $buffer = SPVM::StringBuffer->new_opt([(object)capacity => 1]);
+    $buffer->push_char('a');
+    unless ($buffer->to_str eq "a" && $buffer->capacity == 1) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->push_char('b');
+    unless ($buffer->to_str eq "ab" && $buffer->capacity == 2) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->push_char('c');
+    unless ($buffer->to_str eq "abc" && $buffer->capacity == 4) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    return 1;
+  }
+
   sub test_append_copy_on_write : int () {
     warn("TODO: append copy-on-write test is not implemented yet");
     return 0;

--- a/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/StringBuffer.spvm
@@ -152,6 +152,27 @@ package TestCase::Lib::SPVM::StringBuffer {
     return 1;
   }
 
+  sub test_push_range  : int () {
+    my $buffer = SPVM::StringBuffer->new_opt([(object)capacity => 1]);
+    my $string = "abcde";
+    $buffer->push_range($string, 0, 3);
+    unless ($buffer->to_str eq "abc" && $buffer->capacity == 3) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->push_range($string, 1, 3);
+    unless ($buffer->to_str eq "abcbcd" && $buffer->capacity == 6) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    $buffer->push_range($string, 2, 3);
+    unless ($buffer->to_str eq "abcbcdcde" && $buffer->capacity == 12) {
+      warn("actual string: " . $buffer->to_str . ", capacity: " . $buffer->capacity);
+      return 0;
+    }
+    return 1;
+  }
+
   sub test_append_copy_on_write : int () {
     warn("TODO: append copy-on-write test is not implemented yet");
     return 0;

--- a/t/default/modules/SPVM-StringBuffer.t
+++ b/t/default/modules/SPVM-StringBuffer.t
@@ -19,6 +19,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::Lib::SPVM::StringBuffer->test_substr);
   ok(TestCase::Lib::SPVM::StringBuffer->test_push);
   ok(TestCase::Lib::SPVM::StringBuffer->test_push_char);
+  ok(TestCase::Lib::SPVM::StringBuffer->test_push_range);
   ok(TestCase::Lib::SPVM::StringBuffer->test_to_str);
   ok(TestCase::Lib::SPVM::StringBuffer->test_index);
 }

--- a/t/default/modules/SPVM-StringBuffer.t
+++ b/t/default/modules/SPVM-StringBuffer.t
@@ -18,6 +18,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::Lib::SPVM::StringBuffer->test_length);
   ok(TestCase::Lib::SPVM::StringBuffer->test_substr);
   ok(TestCase::Lib::SPVM::StringBuffer->test_push);
+  ok(TestCase::Lib::SPVM::StringBuffer->test_push_char);
   ok(TestCase::Lib::SPVM::StringBuffer->test_to_str);
   ok(TestCase::Lib::SPVM::StringBuffer->test_index);
 }


### PR DESCRIPTION
https://github.com/yuki-kimoto/SPVM/issues/129

`SPVM::StringBuffer` に必要なメソッドの追加をします。

- `sub push_range($self : self, $str : string, $offset : int, $len : length);`
  - `substr` のオブジェクト生成コストがかからない substring の push
- `sub push_char($self : self, $char : byte);`
  - 1 byte 文字の `push`