### PR TITLE
JSONのリファクタリング レビュー対応

### DIFF
--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -86,21 +86,20 @@ package SPVM::JSON {
       my $char = $json->[$$iter];
       if ($special_char_expected) {
         switch ((int)$char) {
-          case 34: # '"'
-          case 92: # '\\'
-          {
+          case '"':
+          case '\\': {
             $buffer->push_char($char);
             break;
           }
-          case 116: { # 't'
+          case 't': {
             $buffer->push_char('\t');
             break;
           }
-          case 110: { # 'n'
+          case 'n': {
             $buffer->push_char('\n');
             break;
           }
-          case 114: { # 'r'
+          case 'r': {
             $buffer->push_char('\r');
             break;
           }
@@ -385,24 +384,24 @@ package SPVM::JSON {
       my $char = $string->[$i];
       my $special : byte = -1;
       switch ((int)$char) {
-        case 9: {# '\t'
+        case '\t': {
           # Note: Decoded char from literal ASCII tab will be encoded with "\\t" (non-reversible).
           $special = 't';
           break;
         }
-        case 10: { # '\n'
+        case '\n': {
           $special = 'n';
           break;
         }
-        case 13: { # '\r'
+        case '\r': {
           $special = 'r';
           break;
         }
-        case 34: { # '"'
+        case '"': {
           $special = '"';
           break;
         }
-        case 92: { # '\\'
+        case '\\': {
           $special = '\\';
           break;
         }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -557,7 +557,7 @@ package SPVM::JSON {
     $self->_skip_spaces($json, \$iter);
     my $length = length $json;
     unless ($iter == $length) {
-      _decode_error("Not all json_text is decoded yet", $json, $iter);
+      _decode_error("garbage after JSON object", $json, $iter);
     }
 
     return $spvm_data;

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -87,8 +87,17 @@ package SPVM::JSON {
       if ($special_char_expected) {
         switch ((int)$char) {
           case '"':
-          case '\\': {
+          case '\\':
+          case '/': {
             $buffer->push_char($char);
+            break;
+          }
+          case 'b': {
+            $buffer->push_char('\b');
+            break;
+          }
+          case 'f': {
+            $buffer->push_char('\f');
             break;
           }
           case 'n': {
@@ -390,6 +399,18 @@ package SPVM::JSON {
         }
         case '\\': {
           $special = '\\';
+          break;
+        }
+        case '/': {
+          $special = '/';
+          break;
+        }
+        case '\b': {
+          $special = 'b';
+          break;
+        }
+        case '\f': {
+          $special = 'f';
           break;
         }
         case '\n': {

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -114,8 +114,8 @@ package SPVM::JSON {
         $special_char_expected = 1;
       }
       else {
-        if ($char == '\t') {
-          _decode_error("Literal ASCII tab characters are not allowed in string", $json, $$iter);
+        if ($char <= 31 || $char == 127) {
+          _decode_error("Control ASCII characters are not allowed in string", $json, $$iter);
         }
         $buffer->push_char($char);
       }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -554,7 +554,11 @@ package SPVM::JSON {
     my $iter = 0;
     my $spvm_data = $self->_decode_recursive($json, \$iter);
 
+    # allow $json to have trailing spaces.
     $self->_skip_spaces($json, \$iter);
+
+    # do not allow $json to have non-space string after a json object,
+    # something like `{"key":1} [1,2]`
     my $length = length $json;
     unless ($iter == $length) {
       _decode_error("garbage after JSON object", $json, $iter);

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -231,6 +231,10 @@ package SPVM::JSON {
     my $neg = 0;
 
     if ($json->[$$iter] == '-') {
+      my $length = length $json;
+      unless ($$iter + 1 < $length && isdigit($json->[$$iter + 1])) {
+        _decode_error("malformed number (no digits after '-')", $json, $$iter);
+      }
       ++$$iter;
       $neg = 1;
     }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -91,16 +91,16 @@ package SPVM::JSON {
             $buffer->push_char($char);
             break;
           }
-          case 't': {
-            $buffer->push_char('\t');
-            break;
-          }
           case 'n': {
             $buffer->push_char('\n');
             break;
           }
           case 'r': {
             $buffer->push_char('\r');
+            break;
+          }
+          case 't': {
+            $buffer->push_char('\t');
             break;
           }
           default: {
@@ -384,9 +384,12 @@ package SPVM::JSON {
       my $char = $string->[$i];
       my $special : byte = -1;
       switch ((int)$char) {
-        case '\t': {
-          # Note: Decoded char from literal ASCII tab will be encoded with "\\t" (non-reversible).
-          $special = 't';
+        case '"': {
+          $special = '"';
+          break;
+        }
+        case '\\': {
+          $special = '\\';
           break;
         }
         case '\n': {
@@ -397,12 +400,9 @@ package SPVM::JSON {
           $special = 'r';
           break;
         }
-        case '"': {
-          $special = '"';
-          break;
-        }
-        case '\\': {
-          $special = '\\';
+        case '\t': {
+          # Note: Decoded char from literal ASCII tab will be encoded with "\\t" (non-reversible).
+          $special = 't';
           break;
         }
       }

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -295,7 +295,8 @@ package SPVM::JSON {
       _expect_char($json, $iter, ':');
 
       # value
-      $hash->set($key, $self->_decode_recursive($json, $iter));
+      my $value = $self->_decode_recursive($json, $iter);
+      $hash->set($key, $value);
     }
 
     _expect_char($json, $iter, '}');

--- a/lib/SPVM/JSON.spvm
+++ b/lib/SPVM/JSON.spvm
@@ -72,20 +72,6 @@ package SPVM::JSON {
     }
   }
 
-  precompile private sub _expect_or_rewind : int ($json : string, $iter : int&, $expected : string) {
-    my $end = length $json;
-    my $length = length $expected;
-    unless ($$iter + $length <= $end) {
-      return 0;
-    }
-    my $got = substr($json, $$iter, $length);
-    if ($got eq $expected) {
-      $$iter += $length;
-      return 1;
-    }
-    return 0;
-  }
-
   precompile private sub _decode_string : string ($self : self, $json : string, $iter : int&) {
     my $end = length $json;
     my $buffer = SPVM::StringBuffer->new;
@@ -240,22 +226,6 @@ package SPVM::JSON {
 
   # https://metacpan.org/pod/Cpanel::JSON::XS#number
   precompile private sub _decode_num : object ($self : self, $json : string, $iter : int&) {
-
-    switch ((int)$json->[$$iter]) {
-      case 'i': {
-        unless (_expect_or_rewind($json, $iter, "inf")) {
-          _decode_error("malformed number.", $json, $$iter);
-        }
-        return undef;
-      }
-      case '-': {
-        if (_expect_or_rewind($json, $iter, "-inf")) {
-          return undef;
-        }
-        break;
-      }
-    }
-
     my $accum = 0.0;
     my $expo = 0;
     my $neg = 0;
@@ -382,7 +352,7 @@ package SPVM::JSON {
       case '"': {
         return $self->_decode_string($json, $iter);
       }
-      case '-': case 'i':
+      case '-':
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
         return $self->_decode_num($json, $iter);
@@ -394,10 +364,7 @@ package SPVM::JSON {
         return $self->_decode_false($json, $iter);
       }
       case 'n': {
-        unless (_expect_or_rewind($json, $iter, "nan") ||
-                _expect_or_rewind($json, $iter, "null")) {
-          _decode_error("malformed number.", $json, $$iter);
-        }
+        _expect_token($json, $iter, "null");
         return undef;
       }
       default: {

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -382,6 +382,16 @@ package TestCase::JSON {
         return 0;
       }
     }
+    {
+      eval {
+        $DEFAULT_JSON->decode("-");
+      };
+      unless ($@ && contains($@, "malformed number (no digits after '-')")) {
+        $@ = undef;
+        return 0;
+      }
+      $@ = undef;
+    }
     return 1;
   }
 

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -608,21 +608,4 @@ package TestCase::JSON {
     }
     return 1;
   }
-
-  sub decode_inf : int () {
-    unless ($DEFAULT_JSON->decode("inf") == undef) {
-      return 0;
-    }
-    unless ($DEFAULT_JSON->decode("-inf") == undef) {
-      return 0;
-    }
-    return 1;
-  }
-
-  sub decode_nan : int () {
-    unless ($DEFAULT_JSON->decode("nan") == undef) {
-      return 0;
-    }
-    return 1;
-  }
 }

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -548,6 +548,27 @@ package TestCase::JSON {
         return 0;
       }
     }
+    # control characters are not allowed
+    {
+      for (my $ch : byte = 0; $ch <= 31; ++$ch) {
+        eval {
+          $DEFAULT_JSON->decode("\"" . [ $ch ] . "\"");
+        };
+        unless ($@ && contains($@, "Control ASCII characters are not allowed in string")) {
+          $@ = undef;
+          return 0;
+        }
+        $@ = undef;
+      }
+      eval {
+        $DEFAULT_JSON->decode("\"" . [ (byte)127 ] . "\"");
+      };
+      unless ($@ && contains($@, "Control ASCII characters are not allowed in string")) {
+        $@ = undef;
+        return 0;
+      }
+      $@ = undef;
+    }
     return 1;
   }
 

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -445,15 +445,6 @@ package TestCase::JSON {
       }
     }
     # special characters
-    # '\'
-    {
-      my $input = "\\";
-      my $got = $DEFAULT_JSON->encode($input);
-      my $expected = "\"\\\\\"";
-      unless (_equals($got, $expected)) {
-        return 0;
-      }
-    }
     # '"'
     {
       my $input = "\"";
@@ -463,11 +454,11 @@ package TestCase::JSON {
         return 0;
       }
     }
-    # '\t'
+    # '\'
     {
-      my $input = "\t";
+      my $input = "\\";
       my $got = $DEFAULT_JSON->encode($input);
-      my $expected = "\"\\t\"";
+      my $expected = "\"\\\\\"";
       unless (_equals($got, $expected)) {
         return 0;
       }
@@ -490,6 +481,15 @@ package TestCase::JSON {
         return 0;
       }
     }
+    # '\t'
+    {
+      my $input = "\t";
+      my $got = $DEFAULT_JSON->encode($input);
+      my $expected = "\"\\t\"";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
     return 1;
   }
 
@@ -503,15 +503,6 @@ package TestCase::JSON {
       }
     }
     # special characters
-    # '\'
-    {
-      my $input = "\"\\\\\"";
-      my $got = $DEFAULT_JSON->decode($input);
-      my $expected = "\\";
-      unless (_equals($got, $expected)) {
-        return 0;
-      }
-    }
     # '"'
     {
       my $input = "\"\\\"\"";
@@ -521,11 +512,11 @@ package TestCase::JSON {
         return 0;
       }
     }
-    # '\t'
+    # '\'
     {
-      my $input = "\"\\t\"";
+      my $input = "\"\\\\\"";
       my $got = $DEFAULT_JSON->decode($input);
-      my $expected = "\t";
+      my $expected = "\\";
       unless (_equals($got, $expected)) {
         return 0;
       }
@@ -544,6 +535,15 @@ package TestCase::JSON {
       my $input = "\"\\r\"";
       my $got = $DEFAULT_JSON->decode($input);
       my $expected = "\r";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '\t'
+    {
+      my $input = "\"\\t\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "\t";
       unless (_equals($got, $expected)) {
         return 0;
       }

--- a/t/default/lib/TestCase/JSON.spvm
+++ b/t/default/lib/TestCase/JSON.spvm
@@ -521,6 +521,33 @@ package TestCase::JSON {
         return 0;
       }
     }
+    # '/'
+    {
+      my $input = "\"\\/\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "/";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '\b'
+    {
+      my $input = "\"\\b\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "\b";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
+    # '\f'
+    {
+      my $input = "\"\\f\"";
+      my $got = $DEFAULT_JSON->decode($input);
+      my $expected = "\f";
+      unless (_equals($got, $expected)) {
+        return 0;
+      }
+    }
     # '\n'
     {
       my $input = "\"\\n\"";

--- a/t/default/modules/SPVM-JSON.t
+++ b/t/default/modules/SPVM-JSON.t
@@ -26,8 +26,6 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
 # decode
 {
   ok(TestCase::JSON->decode_null);
-  ok(TestCase::JSON->decode_inf);
-  ok(TestCase::JSON->decode_nan);
   ok(TestCase::JSON->decode_flat_hash);
   ok(TestCase::JSON->decode_flat_list);
   ok(TestCase::JSON->decode_double);


### PR DESCRIPTION
https://github.com/yuki-kimoto/SPVM/issues/129#issuecomment-534813669 で頂いたレビューの対応です。

- [x] decode関数内でコメント f3f384e
- [x] _expect_or_rewind の削除 3579200
- [x] nan の削除 3579200
- [x] infはunexpected tokenではじく 3579200
- [x] nullの場合の処理 3579200
- [x] 数値の解析の先頭のiを削除 3579200
- [x] setする前に変数へ bb9b14b
- [x] ASCIIコードの制御文字はすべてはじく cc2fb75
- [x] JSON文字列のエスケープ不足 67d0482
- [x] _escape_stringのswitchの不足 bb1cb4d