### PR TITLE
sprintf rework

### DIFF
--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -4,6 +4,7 @@ package SPVM::Util {
   use SPVM::EqualityChecker;
   use SPVM::StringBuffer;
   use SPVM::StringList;
+  use SPVM::Math (fabs, floor, log10, pow);
 
   BEGIN {
     _setup_sprintf();
@@ -122,6 +123,76 @@ package SPVM::Util {
     $SPECIFIER_TYPE_OF->[(int)'s'] = SPVM::Util->SPECIFIER_S;
   }
 
+  # TODO: Add the 2nd argument for width.
+  precompile sub _convert_d_to_str : string ($value : int) {
+    my $string = "" . $value;
+    my $width = 1; # TODO: Move $width to the argument.
+
+    my $value_length = length $string;
+    if ($value_length < $width) {
+      my $buffer = SPVM::StringBuffer->new;
+      my $space_count = $width - $value_length;
+      for (my $i = 0; $i < $space_count; ++$i) {
+        $buffer->push_char(' ');
+      }
+      $buffer->push($string);
+      $string = $buffer->to_str;
+    }
+
+    return $string;
+  }
+
+  # TODO: Add the 2nd argument for width.
+  precompile sub _convert_ld_to_str : string ($value : long) {
+    my $string = "" . $value;
+    my $width = 1; # TODO: Move $width to the argument.
+
+    my $value_length = length $string;
+    if ($value_length < $width) {
+      my $buffer = SPVM::StringBuffer->new;
+      my $space_count = $width - $value_length;
+      for (my $i = 0; $i < $space_count; ++$i) {
+        $buffer->push_char(' ');
+      }
+      $buffer->push($string);
+      $string = $buffer->to_str;
+    }
+
+    return $string;
+  }
+
+  # TODO: Add the 2nd argument for precision.
+  precompile sub _convert_f_to_str : string ($double : double) {
+    my $buffer = SPVM::StringBuffer->new;
+    my $precision = 5; # TODO: Move $precision to the argument.
+
+    if ($double == 0) {
+      $buffer->push_char('0');
+      if ($precision > 1) {
+        $buffer->push_char('.');
+        for (my $i = 0; $i < $precision - 1; ++$precision) {
+          $buffer->push_char('0');
+        }
+      }
+      return $buffer->to_str;
+    }
+
+    # https://stackoverflow.com/a/29583280
+    my $exp = 1 + floor(log10(fabs($double))); # $double != 0
+    my $frac_mantissa = $double * pow(10 , -$exp);
+    for (my $i = 0; $i < $precision; ++$i) {
+      my $upper_pow = pow(10, $exp + $i);
+      my $digit = (byte)($frac_mantissa * $upper_pow);
+      if ($exp == $i) {
+        $buffer->push_char('.');
+      }
+      $buffer->push_char((byte)('0' + $digit));
+      $frac_mantissa -= $digit * pow(10, -($exp + $i));
+    }
+
+    return $buffer->to_str;
+  }
+
   precompile sub sprintf : string ($format : string, $args : object[]...) {
     my $format_length = length $format;
     my $index = 0;
@@ -190,19 +261,22 @@ package SPVM::Util {
         case SPVM::Util->SPECIFIER_D: {
           ++$specifier_length;
           my $arg = (SPVM::Int)$args->[$specifier_count];
-          $output->push($arg->val);
+          my $str = _convert_d_to_str($arg->val);
+          $output->push($str);
           break;
         }
         case SPVM::Util->SPECIFIER_LD: {
           $specifier_length += 2;
           my $arg = (SPVM::Long)$args->[$specifier_count];
-          $output->push($arg->val);
+          my $str = _convert_ld_to_str($arg->val);
+          $output->push($str);
           break;
         }
         case SPVM::Util->SPECIFIER_F: {
           ++$specifier_length;
           my $arg = (SPVM::Double)$args->[$specifier_count];
-          $output->push($arg->val);
+          my $str = _convert_f_to_str($arg->val);
+          $output->push($str);
           break;
         }
         case 'U': {

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -105,7 +105,7 @@ package SPVM::Util {
   }
 
   private enum {
-    SPECIFIER_C,
+    SPECIFIER_C = 1,
     SPECIFIER_D,
     SPECIFIER_F,
     SPECIFIER_S,
@@ -128,25 +128,30 @@ package SPVM::Util {
 
     my $output = SPVM::StringBuffer->new;
     my $specifier_count = 0;
-    my $text_length = 0;
 
-    while ($index < $format_length) {
-      while ($index + $text_length < $format_length &&
-          $format->[$index + $text_length] != '%') {
-        ++$text_length;
+    while (1) {
+      my $next_index = $index;
+      while ($next_index < $format_length && $format->[$next_index] != '%') {
+        ++$next_index;
       }
-      if ($index + $text_length + 1 < $format_length &&
-          $format->[$index + $text_length + 1] == '%') {
-        ++$text_length;
+
+      if ($next_index + 1 == $format_length && $format->[$next_index] == '%') {
+        die "Invalid conversion in sprintf: end of string";
+      }
+
+      if ($next_index + 1 < $format_length &&
+          $format->[$next_index] == '%' && $format->[$next_index + 1] == '%') {
+        $next_index += 2;
         next;
       }
 
-      $output->push_range($format, $index, $text_length);
-      $index += $text_length;
-      $text_length = 0;
+      if (my $text_length = $next_index - $index) {
+        $output->push_range($format, $index, $text_length);
+        $index = $next_index;
+      }
 
       unless ($index + 1 < $format_length) {
-        die "Invalid conversion in sprintf: end of string";
+        last;
       }
 
       unless ($specifier_count < @$args) {
@@ -200,7 +205,7 @@ package SPVM::Util {
           break;
         }
         default: {
-          die "Invalid conversion in sprintf: \"%" . [(byte) $specifier_type] ."\"";
+          die "Invalid conversion in sprintf: \"%" . [$format->[$index]] . "\"";
           break;
         }
       }

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -4,6 +4,7 @@ package SPVM::Util {
   use SPVM::EqualityChecker;
   use SPVM::StringBuffer;
   use SPVM::StringList;
+  use SPVM::Unicode (uchar_to_utf8);
   use SPVM::Math (fabs, floor, log10, pow);
 
   BEGIN {
@@ -110,6 +111,7 @@ package SPVM::Util {
     SPECIFIER_D,
     SPECIFIER_F,
     SPECIFIER_S,
+    SPECIFIER_U,
     SPECIFIER_LD,
   }
 
@@ -121,6 +123,7 @@ package SPVM::Util {
     $SPECIFIER_TYPE_OF->[(int)'d'] = SPVM::Util->SPECIFIER_D;
     $SPECIFIER_TYPE_OF->[(int)'f'] = SPVM::Util->SPECIFIER_F;
     $SPECIFIER_TYPE_OF->[(int)'s'] = SPVM::Util->SPECIFIER_S;
+    $SPECIFIER_TYPE_OF->[(int)'U'] = SPVM::Util->SPECIFIER_U;
   }
 
   # TODO: Add the 2nd argument for width.
@@ -279,8 +282,11 @@ package SPVM::Util {
           $output->push($str);
           break;
         }
-        case 'U': {
-          die "Not implemented yet";
+        case SPVM::Util->SPECIFIER_U: {
+          ++$specifier_length;
+          my $arg = (SPVM::Int)$args->[$specifier_count];
+          my $utf8 = uchar_to_utf8($arg->val);
+          $output->push($utf8);
           break;
         }
         default: {

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -158,44 +158,49 @@ package SPVM::Util {
         die "Missing argument in sprintf";
       }
 
-      ++$index; # read '%'
+      my $specifier_length = 1; # '%'
 
       my $specifier_type : int;
-      if ($format->[$index] == 'l') {
-        if ($format->[$index + 1] == 'd') {
+      if ($format->[$index + $specifier_length] == 'l') {
+        if ($index + $specifier_length + 1 < $format_length &&
+            $format->[$index + $specifier_length + 1] == 'd') {
           $specifier_type = SPVM::Util->SPECIFIER_LD;
         }
         else {
-          die "Invalid conversion in sprintf: \"%" . [$format->[$index]] ."\"";
+          die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length + 1) ."\"";
         }
       }
       else {
-        $specifier_type = $SPECIFIER_TYPE_OF->[$format->[$index]];
+        $specifier_type = $SPECIFIER_TYPE_OF->[$format->[$index + $specifier_length]];
       }
 
       switch ($specifier_type) {
         case SPVM::Util->SPECIFIER_C: {
+          ++$specifier_length;
           my $arg = (SPVM::Byte)$args->[$specifier_count];
           $output->push_char($arg->val);
           break;
         }
         case SPVM::Util->SPECIFIER_S: {
+          ++$specifier_length;
           my $arg = (string)$args->[$specifier_count];
           $output->push($arg);
           break;
         }
         case SPVM::Util->SPECIFIER_D: {
+          ++$specifier_length;
           my $arg = (SPVM::Int)$args->[$specifier_count];
           $output->push($arg->val);
           break;
         }
         case SPVM::Util->SPECIFIER_LD: {
-          ++$index;
+          $specifier_length += 2;
           my $arg = (SPVM::Long)$args->[$specifier_count];
           $output->push($arg->val);
           break;
         }
         case SPVM::Util->SPECIFIER_F: {
+          ++$specifier_length;
           my $arg = (SPVM::Double)$args->[$specifier_count];
           $output->push($arg->val);
           break;
@@ -205,12 +210,12 @@ package SPVM::Util {
           break;
         }
         default: {
-          die "Invalid conversion in sprintf: \"%" . [$format->[$index]] . "\"";
+          die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length + 1) . "\"";
           break;
         }
       }
 
-      ++$index;
+      $index += $specifier_length;
       ++$specifier_count;
     }
 

--- a/t/default/lib/TestCase/Lib/SPVM/Util.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Util.spvm
@@ -262,10 +262,10 @@ package TestCase::Lib::SPVM::Util {
 
   sub test_sprintf_f : int () {
     my $tests = [
-        [ sprintf("abc%f", 3.14),               "abc3.14"       ],
-        [ sprintf("%fabc", 3.14),               "3.14abc"       ],
-        [ sprintf("%fabc%f", 3.14, 2.71),       "3.14abc2.71"   ],
-        [ sprintf("%f%f%f", 3.14, 2.71, 2.67),  "3.142.712.67"  ],
+        [ sprintf("abc%f", 3.14),               "abc3.1400"           ],
+        [ sprintf("%fabc", 3.14),               "3.1400abc"           ],
+        [ sprintf("%fabc%f", 3.14, 2.71),       "3.1400abc2.7100"     ],
+        [ sprintf("%f%f%f", 3.14, 2.71, 2.67),  "3.14002.71002.6700"  ],
     ];
     for (my $i = 0; $i < @$tests; ++$i) {
       unless ($tests->[$i][0] eq $tests->[$i][1]) {

--- a/t/default/lib/TestCase/Lib/SPVM/Util.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Util.spvm
@@ -199,145 +199,180 @@ package TestCase::Lib::SPVM::Util {
   }
 
   sub test_sprintf_d : int () {
-    my $got = sprintf("hoge:%d", 123);
-    my $expected = "hoge:123";
-    unless ($got eq $expected) {
-      return 0;
+    my $tests = [
+        [ sprintf("abc%d", 123),          "abc123"  ],
+        [ sprintf("%dabc", 123),          "123abc"  ],
+        [ sprintf("%dabc%d", 1, 10),      "1abc10"  ],
+        [ sprintf("%d%d%d", 1, 10, 100),  "110100"  ],
+    ];
+    for (my $i = 0; $i < @$tests; ++$i) {
+      unless ($tests->[$i][0] eq $tests->[$i][1]) {
+        warn("got: '" . $tests->[$i][0] . "', expected: '" . $tests->[$i][1] . "'");
+        return 0;
+      }
     }
-    eval {
-      sprintf("hoge:%d", "str");
-    };
-    if (contains($@, "Can't cast")) {
+    {
+      eval {
+        sprintf("%d", "str");
+      };
+      unless ($@ && contains($@, "Can't cast")) {
+        warn("got error: $@");
+        return 0;
+      }
       $@ = undef;
-      return 1;
     }
-    else {
-      warn($@);
-      return 0;
-    }
+    return 1;
   }
 
   sub test_sprintf_ld : int () {
-    my $got = sprintf("hoge:%ld", 10000000000L);
-    my $expected = "hoge:10000000000";
-    unless ($got eq $expected) {
-      return 0;
+    my $tests = [
+        [ sprintf("abc%ld", 10000000000L),                                "abc10000000000"                    ],
+        [ sprintf("%ldabc", 10000000000L),                                "10000000000abc"                    ],
+        [ sprintf("%ldabc%ld", 10000000000L, 20000000000L),               "10000000000abc20000000000"         ],
+        [ sprintf("%ld%ld%ld", 10000000000L, 20000000000L, 30000000000L), "100000000002000000000030000000000" ],
+    ];
+    for (my $i = 0; $i < @$tests; ++$i) {
+      unless ($tests->[$i][0] eq $tests->[$i][1]) {
+        warn("got: '" . $tests->[$i][0] . "', expected: '" . $tests->[$i][1] . "'");
+        return 0;
+      }
     }
-    eval {
-      sprintf("hoge:%ld", "str");
-    };
-    if (contains($@, "Can't cast")) {
+    {
+      eval {
+        sprintf("%ld", "str");
+      };
+      unless ($@ && contains($@, "Can't cast")) {
+        warn("got error: $@");
+        return 0;
+      }
       $@ = undef;
-      return 1;
     }
-    else {
-      warn($@);
-      return 0;
-    }
+    return 1;
   }
 
   sub test_sprintf_f : int () {
-    my $got = sprintf("hoge:%f", 3.14);
-    my $expected = "hoge:3.14";
-    unless ($got eq $expected) {
-      return 0;
+    my $tests = [
+        [ sprintf("abc%f", 3.14),               "abc3.14"       ],
+        [ sprintf("%fabc", 3.14),               "3.14abc"       ],
+        [ sprintf("%fabc%f", 3.14, 2.71),       "3.14abc2.71"   ],
+        [ sprintf("%f%f%f", 3.14, 2.71, 2.67),  "3.142.712.67"  ],
+    ];
+    for (my $i = 0; $i < @$tests; ++$i) {
+      unless ($tests->[$i][0] eq $tests->[$i][1]) {
+        warn("got: '" . $tests->[$i][0] . "', expected: '" . $tests->[$i][1] . "'");
+        return 0;
+      }
     }
-    eval {
-      sprintf("hoge:%f", "str");
-    };
-    if (contains($@, "Can't cast")) {
+    {
+      eval {
+        sprintf("%f", "str");
+      };
+      unless ($@ && contains($@, "Can't cast")) {
+        warn("got error: $@");
+        return 0;
+      }
       $@ = undef;
-      return 1;
-    }
-    else {
-      warn($@);
-      return 0;
     }
     return 1;
   }
 
   sub test_sprintf_c : int () {
-    my $got = sprintf("hoge:%c", 'c');
-    my $expected = "hoge:c";
-    unless ($got eq $expected) {
-      return 0;
+    my $tests = [
+        [ sprintf("abc%c", 'x'),            "abcx"  ],
+        [ sprintf("%cabc", 'x'),            "xabc"  ],
+        [ sprintf("%cabc%c", 'x', 'y'),     "xabcy" ],
+        [ sprintf("%c%c%c", 'x', 'y', 'z'), "xyz"   ],
+    ];
+    for (my $i = 0; $i < @$tests; ++$i) {
+      unless ($tests->[$i][0] eq $tests->[$i][1]) {
+        warn("got: '" . $tests->[$i][0] . "', expected: '" . $tests->[$i][1] . "'");
+        return 0;
+      }
     }
-    eval {
-      sprintf("hoge:%c", "str");
-    };
-    if (contains($@, "Can't cast")) {
+    {
+      eval {
+        sprintf("%c", "str");
+      };
+      unless ($@ && contains($@, "Can't cast")) {
+        warn("got error: $@");
+        return 0;
+      }
       $@ = undef;
-      return 1;
-    }
-    else {
-      warn($@);
-      return 0;
     }
     return 1;
   }
 
   sub test_sprintf_s : int () {
-    my $got = sprintf("hoge:%s", "str");
-    my $expected = "hoge:str";
-    unless ($got eq $expected) {
-      return 0;
+    my $tests = [
+        [ sprintf("abc%s", "ABC"),                "abcABC"    ],
+        [ sprintf("%sabc", "ABC"),                "ABCabc"    ],
+        [ sprintf("%sabc%s", "ABC", "XYZ"),       "ABCabcXYZ" ],
+        [ sprintf("%s%s%s", "ABC", "XYZ", "123"), "ABCXYZ123" ],
+    ];
+    for (my $i = 0; $i < @$tests; ++$i) {
+      unless ($tests->[$i][0] eq $tests->[$i][1]) {
+        warn("got: '" . $tests->[$i][0] . "', expected: '" . $tests->[$i][1] . "'");
+        return 0;
+      }
     }
-    eval {
-      sprintf("hoge:%str", 1);
-    };
-    if (contains($@, "Can't cast")) {
+    {
+      eval {
+        sprintf("%s", 1);
+      };
+      unless ($@ && contains($@, "Can't cast")) {
+        warn("got error: $@");
+        return 0;
+      }
       $@ = undef;
-      return 1;
-    }
-    else {
-      warn($@);
-      return 0;
     }
     return 1;
   }
 
   sub test_sprintf_all : int () {
-    # Invalid conversion (end of string)
-    eval {
-      sprintf("%d%", 1);
-    };
-    if (contains($@, "Invalid conversion in sprintf: end of string")) {
+    {
+      # Invalid conversion (end of string)
+      eval {
+        sprintf("%d%", 1);
+      };
+      unless ($@ && contains($@, "Invalid conversion in sprintf: end of string")) {
+        warn("got error: $@");
+        return 0;
+      }
       $@ = undef;
     }
-    else {
-      return 0;
-    }
-    # Invalid conversion (unknown specifier)
-    eval {
-      sprintf("%d%k", 1);
-    };
-    if (contains($@, "Invalid conversion in sprintf: \"%k\"")) {
+    {
+      # Invalid conversion (unknown specifier)
+      eval {
+        sprintf("%d%k", 1, 2);
+      };
+      unless ($@ && contains($@, "Invalid conversion in sprintf: \"%k\"")) {
+        warn("got error: $@");
+        return 0;
+      }
       $@ = undef;
     }
-    else {
-      return 0;
-    }
-    # Redundant argument
-    eval {
-      sprintf("%d", 1, 2);
-    };
-    if (contains($@, "Redundant argument in sprintf")) {
+    {
+      # Redundant argument
+      eval {
+        sprintf("%d", 1, 2);
+      };
+      unless ($@ && contains($@, "Redundant argument in sprintf")) {
+        warn("got error: $@");
+        return 0;
+      }
       $@ = undef;
     }
-    else {
-      return 0;
-    }
-    # Missing argument
-    eval {
-      sprintf("%d%d", 1);
-    };
-    if (contains($@, "Missing argument in sprintf")) {
+    {
+      # Missing argument
+      eval {
+        sprintf("%d%d", 1);
+      };
+      unless ($@ && contains($@, "Missing argument in sprintf")) {
+        warn("got error: $@");
+        return 0;
+      }
       $@ = undef;
     }
-    else {
-      return 0;
-    }
-
     return 1;
   }
 }

--- a/t/default/lib/TestCase/Lib/SPVM/Util.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Util.spvm
@@ -247,6 +247,16 @@ package TestCase::Lib::SPVM::Util {
       }
       $@ = undef;
     }
+    {
+      eval {
+        sprintf("%l", 1L);
+      };
+      unless ($@ && contains($@, "Invalid conversion in sprintf: \"%l\"")) {
+        warn("got error: $@");
+        return 0;
+      }
+      $@ = undef;
+    }
     return 1;
   }
 

--- a/t/default/lib/TestCase/Lib/SPVM/Util.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Util.spvm
@@ -1,5 +1,6 @@
 package TestCase::Lib::SPVM::Util {
   use SPVM::Util(joino, split, copy_oarray, equals_oarray, sprintf);
+  use SPVM::Unicode (uchar);
   use TestCase::Minimal;
 
   sub test_equals_oarray : int () {
@@ -328,6 +329,37 @@ package TestCase::Lib::SPVM::Util {
     {
       eval {
         sprintf("%s", 1);
+      };
+      unless ($@ && contains($@, "Can't cast")) {
+        warn("got error: $@");
+        return 0;
+      }
+      $@ = undef;
+    }
+    return 1;
+  }
+
+  private sub _first_uchar : int ($str : string) {
+    my $uchar_pos = 0;
+    return uchar($str, \$uchar_pos);
+  }
+
+  sub test_sprintf_U : int () {
+    my $tests = [
+        [ sprintf("abc%U", _first_uchar("あ")), "abcあ" ],
+        [ sprintf("%Uabc", _first_uchar("あ")), "あabc" ],
+        [ sprintf("%Uabc%U", _first_uchar("あ"), _first_uchar("い")), "あabcい" ],
+        [ sprintf("%U%U%U", _first_uchar("あ"), _first_uchar("い"), _first_uchar("う")), "あいう" ],
+    ];
+    for (my $i = 0; $i < @$tests; ++$i) {
+      unless ($tests->[$i][0] eq $tests->[$i][1]) {
+        warn("got: '" . $tests->[$i][0] . "', expected: '" . $tests->[$i][1] . "'");
+        return 0;
+      }
+    }
+    {
+      eval {
+        sprintf("%U", "str");
       };
       unless ($@ && contains($@, "Can't cast")) {
         warn("got error: $@");

--- a/t/default/modules/SPVM-Util.t
+++ b/t/default/modules/SPVM-Util.t
@@ -28,6 +28,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::Lib::SPVM::Util->test_sprintf_f);
   ok(TestCase::Lib::SPVM::Util->test_sprintf_c);
   ok(TestCase::Lib::SPVM::Util->test_sprintf_s);
+  ok(TestCase::Lib::SPVM::Util->test_sprintf_U);
   ok(TestCase::Lib::SPVM::Util->test_sprintf_all);
 }
 


### PR DESCRIPTION
#128 の未対応箇所とバグ修正の PR です。
- [x] 書式指定子の長さの管理
- [x] 数値と文字列の変換 (`width = 1`, `precision = 5` 固定値で実装)
- [x] #128 のバグ/テスト修正