### PR TITLE
sprintf レビュー修正の続き

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -128,6 +128,7 @@ sub MY::postamble {
     $make_rule .= SPVM::Builder::Util::create_make_rule_native('SPVM::Sort');
     $make_rule .= SPVM::Builder::Util::create_make_rule_native('SPVM::Unistd');
     $make_rule .= SPVM::Builder::Util::create_make_rule_native('SPVM::MIME::Base64');
+    $make_rule .= SPVM::Builder::Util::create_make_rule_native('SPVM::Util');
     
     # Precompile make rule
     $make_rule .= SPVM::Builder::Util::create_make_rule_precompile('SPVM::Sort');

--- a/lib/SPVM/Util.c
+++ b/lib/SPVM/Util.c
@@ -1,0 +1,24 @@
+#include "spvm_native.h"
+
+static const char* MFILE = "SPVM/Util.c";
+
+#define SPRINTF_MAX_RESULT_LEN 256
+
+int32_t SPNATIVE__SPVM__Util___convert_f_to_str(SPVM_ENV* env, SPVM_VALUE* stack) {
+  (void)env;
+
+  void* obj_format = stack[0].oval;
+  if (!obj_format) { SPVM_DIE("Format must be defined", MFILE, __LINE__); }
+
+  const char* format = (const char*)env->belems(env, obj_format);
+  const double value = stack[1].dval;
+
+  char tmp_result[SPRINTF_MAX_RESULT_LEN] = {};
+
+  const int result_len = snprintf(tmp_result, SPRINTF_MAX_RESULT_LEN, format, value);
+  if (result_len < 0) { SPVM_DIE("snprintf fail", MFILE, __LINE__); }
+
+  stack[0].oval = env->new_str_len(env, tmp_result, result_len);
+
+  return SPVM_SUCCESS;
+}

--- a/lib/SPVM/Util.config
+++ b/lib/SPVM/Util.config
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+
+use SPVM::Builder::Config;
+my $bconf = SPVM::Builder::Config->new_c99;
+
+$bconf;

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -140,37 +140,7 @@ package SPVM::Util {
     return $string;
   }
 
-  # TODO: Add the 2nd argument for precision.
-  precompile sub _convert_f_to_str : string ($double : double) {
-    my $buffer = SPVM::StringBuffer->new;
-    my $precision = 5; # TODO: Move $precision to the argument.
-
-    if ($double == 0) {
-      $buffer->push_char('0');
-      if ($precision > 1) {
-        $buffer->push_char('.');
-        for (my $i = 0; $i < $precision - 1; ++$precision) {
-          $buffer->push_char('0');
-        }
-      }
-      return $buffer->to_str;
-    }
-
-    # https://stackoverflow.com/a/29583280
-    my $exp = 1 + floor(log10(fabs($double))); # $double != 0
-    my $frac_mantissa = $double * pow(10 , -$exp);
-    for (my $i = 0; $i < $precision; ++$i) {
-      my $upper_pow = pow(10, $exp + $i);
-      my $digit = (byte)($frac_mantissa * $upper_pow);
-      if ($exp == $i) {
-        $buffer->push_char('.');
-      }
-      $buffer->push_char((byte)('0' + $digit));
-      $frac_mantissa -= $digit * pow(10, -($exp + $i));
-    }
-
-    return $buffer->to_str;
-  }
+  native sub _convert_f_to_str : string ($format : string, $value : double);
 
   precompile sub sprintf : string ($format : string, $args : object[]...) {
     my $format_length = length $format;
@@ -246,7 +216,7 @@ package SPVM::Util {
       elsif ($specifier_char == 'f') {
         ++$specifier_length;
         my $arg = (SPVM::Double)$args->[$specifier_count];
-        my $str = _convert_f_to_str($arg->val);
+        my $str = _convert_f_to_str("%.4f", $arg->val);
         $output->push($str);
       }
       elsif ($specifier_char == 'U') {

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -7,10 +7,6 @@ package SPVM::Util {
   use SPVM::Unicode (uchar_to_utf8);
   use SPVM::Math (fabs, floor, log10, pow);
 
-  BEGIN {
-    _setup_sprintf();
-  }
-
   precompile sub copy_oarray : object[] ($objects : object[], $cloner : SPVM::Cloner) {
     my $length = @$objects;
     
@@ -104,26 +100,6 @@ package SPVM::Util {
     my $separated_strings = $separated_strings_list->to_array;
     
     return $separated_strings;
-  }
-
-  private enum {
-    SPECIFIER_C = 1,
-    SPECIFIER_D,
-    SPECIFIER_F,
-    SPECIFIER_S,
-    SPECIFIER_U,
-    SPECIFIER_LD,
-  }
-
-  our $SPECIFIER_TYPE_OF : private ro byte[];
-
-  precompile sub _setup_sprintf : void () {
-    $SPECIFIER_TYPE_OF = new byte[128];
-    $SPECIFIER_TYPE_OF->[(int)'c'] = SPVM::Util->SPECIFIER_C;
-    $SPECIFIER_TYPE_OF->[(int)'d'] = SPVM::Util->SPECIFIER_D;
-    $SPECIFIER_TYPE_OF->[(int)'f'] = SPVM::Util->SPECIFIER_F;
-    $SPECIFIER_TYPE_OF->[(int)'s'] = SPVM::Util->SPECIFIER_S;
-    $SPECIFIER_TYPE_OF->[(int)'U'] = SPVM::Util->SPECIFIER_U;
   }
 
   # TODO: Add the 2nd argument for width.
@@ -233,66 +209,54 @@ package SPVM::Util {
       }
 
       my $specifier_length = 1; # '%'
+      my $specifier_char = $format->[$index + $specifier_length];
 
-      my $specifier_type : int;
-      if ($format->[$index + $specifier_length] == 'l') {
-        if ($index + $specifier_length + 1 < $format_length &&
-            $format->[$index + $specifier_length + 1] == 'd') {
-          $specifier_type = SPVM::Util->SPECIFIER_LD;
-        }
-        else {
-          die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length + 1) ."\"";
-        }
+      if ($specifier_char == 'c') {
+        ++$specifier_length;
+        my $arg = (SPVM::Byte)$args->[$specifier_count];
+        $output->push_char($arg->val);
       }
-      else {
-        $specifier_type = $SPECIFIER_TYPE_OF->[$format->[$index + $specifier_length]];
+      elsif ($specifier_char == 's') {
+        ++$specifier_length;
+        my $arg = (string)$args->[$specifier_count];
+        $output->push($arg);
       }
-
-      switch ($specifier_type) {
-        case SPVM::Util->SPECIFIER_C: {
-          ++$specifier_length;
-          my $arg = (SPVM::Byte)$args->[$specifier_count];
-          $output->push_char($arg->val);
-          break;
+      elsif ($specifier_char == 'd') {
+        ++$specifier_length;
+        my $arg = (SPVM::Int)$args->[$specifier_count];
+        my $str = _convert_d_to_str($arg->val);
+        $output->push($str);
+      }
+      elsif ($specifier_char == 'l') {
+        ++$specifier_length;
+        unless ($index + $specifier_length < $format_length) {
+          die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length) ."\"";
         }
-        case SPVM::Util->SPECIFIER_S: {
+        my $specifier_char_next = $format->[$index + $specifier_length];
+        if ($specifier_char_next == 'd') {
           ++$specifier_length;
-          my $arg = (string)$args->[$specifier_count];
-          $output->push($arg);
-          break;
-        }
-        case SPVM::Util->SPECIFIER_D: {
-          ++$specifier_length;
-          my $arg = (SPVM::Int)$args->[$specifier_count];
-          my $str = _convert_d_to_str($arg->val);
-          $output->push($str);
-          break;
-        }
-        case SPVM::Util->SPECIFIER_LD: {
-          $specifier_length += 2;
           my $arg = (SPVM::Long)$args->[$specifier_count];
           my $str = _convert_ld_to_str($arg->val);
           $output->push($str);
-          break;
         }
-        case SPVM::Util->SPECIFIER_F: {
-          ++$specifier_length;
-          my $arg = (SPVM::Double)$args->[$specifier_count];
-          my $str = _convert_f_to_str($arg->val);
-          $output->push($str);
-          break;
+        else {
+          die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length) ."\"";
         }
-        case SPVM::Util->SPECIFIER_U: {
-          ++$specifier_length;
-          my $arg = (SPVM::Int)$args->[$specifier_count];
-          my $utf8 = uchar_to_utf8($arg->val);
-          $output->push($utf8);
-          break;
-        }
-        default: {
-          die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length + 1) . "\"";
-          break;
-        }
+      }
+      elsif ($specifier_char == 'f') {
+        ++$specifier_length;
+        my $arg = (SPVM::Double)$args->[$specifier_count];
+        my $str = _convert_f_to_str($arg->val);
+        $output->push($str);
+      }
+      elsif ($specifier_char == 'U') {
+        ++$specifier_length;
+        my $arg = (SPVM::Int)$args->[$specifier_count];
+        my $utf8 = uchar_to_utf8($arg->val);
+        $output->push($utf8);
+      }
+      else {
+        die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length + 1) . "\"";
       }
 
       $index += $specifier_length;

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -104,40 +104,48 @@ package SPVM::Util {
 
   # TODO: Add the 2nd argument for width.
   precompile sub _convert_d_to_str : string ($value : int) {
-    my $string = "" . $value;
+    my $value_str = "$value";
     my $width = 1; # TODO: Move $width to the argument.
 
-    my $value_length = length $string;
-    if ($value_length < $width) {
-      my $buffer = SPVM::StringBuffer->new;
-      my $space_count = $width - $value_length;
-      for (my $i = 0; $i < $space_count; ++$i) {
-        $buffer->push_char(' ');
-      }
-      $buffer->push($string);
-      $string = $buffer->to_str;
+    my $value_length = length $value_str;
+    unless ($value_length < $width) {
+      return $value_str;
     }
 
-    return $string;
+    my $buffer = SPVM::StringBuffer->new;
+    my $space_count = $width - $value_length;
+    for (my $i = 0; $i < $space_count; ++$i) {
+      $buffer->push_char(' ');
+    }
+
+    $buffer->push($value_str);
+
+    my $result = $buffer->to_str;
+
+    return $result;
   }
 
   # TODO: Add the 2nd argument for width.
   precompile sub _convert_ld_to_str : string ($value : long) {
-    my $string = "" . $value;
+    my $value_str = "$value";
     my $width = 1; # TODO: Move $width to the argument.
 
-    my $value_length = length $string;
-    if ($value_length < $width) {
-      my $buffer = SPVM::StringBuffer->new;
-      my $space_count = $width - $value_length;
-      for (my $i = 0; $i < $space_count; ++$i) {
-        $buffer->push_char(' ');
-      }
-      $buffer->push($string);
-      $string = $buffer->to_str;
+    my $value_length = length $value_str;
+    unless ($value_length < $width) {
+      return $value_str;
     }
 
-    return $string;
+    my $buffer = SPVM::StringBuffer->new;
+    my $space_count = $width - $value_length;
+    for (my $i = 0; $i < $space_count; ++$i) {
+      $buffer->push_char(' ');
+    }
+
+    $buffer->push($value_str);
+
+    my $result = $buffer->to_str;
+
+    return $result;
   }
 
   native sub _convert_f_to_str : string ($format : string, $value : double);

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -149,31 +149,43 @@ package SPVM::Util {
     my $output = SPVM::StringBuffer->new;
     my $specifier_count = 0;
 
-    while (1) {
-      my $next_index = $index;
-      while ($next_index < $format_length && $format->[$next_index] != '%') {
-        ++$next_index;
+    while ($index < $format_length) {
+
+      my $normal_str_end = $index;
+
+      # Search the next specifier '%' until the end of $format.
+      while ($normal_str_end < $format_length) {
+        if ($format->[$normal_str_end] != '%') {
+          # ignore "%%"
+          if ($normal_str_end + 1 < $format_length &&
+              $format->[$normal_str_end + 1] == '%') {
+            $normal_str_end += 2;
+          }
+          else {
+            last;
+          }
+        }
+        else {
+          ++$normal_str_end;
+        }
       }
 
-      if ($next_index + 1 == $format_length && $format->[$next_index] == '%') {
+      if ($format->[$normal_str_end] == '%' &&
+          $normal_str_end + 1 == $format_length) {
         die "Invalid conversion in sprintf: end of string";
       }
 
-      if ($next_index + 1 < $format_length &&
-          $format->[$next_index] == '%' && $format->[$next_index + 1] == '%') {
-        $next_index += 2;
-        next;
-      }
-
-      if (my $text_length = $next_index - $index) {
-        $output->push_range($format, $index, $text_length);
-        $index = $next_index;
+      # Output the normal sub-string of $format.
+      if (my $normal_str_length = $normal_str_end - $index) {
+        $output->push_range($format, $index, $normal_str_length);
+        $index = $normal_str_end;
       }
 
       unless ($index + 1 < $format_length) {
         last;
       }
 
+      # Output the next element of $args corresponding to the specifier.
       unless ($specifier_count < @$args) {
         die "Missing argument in sprintf";
       }

--- a/t/default/lib/TestCase/Lib/SPVM/Util.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Util.spvm
@@ -370,6 +370,21 @@ package TestCase::Lib::SPVM::Util {
     return 1;
   }
 
+  sub test_sprintf_percent : int () {
+    my $tests = [
+        [ sprintf("%d%%",    1), "1%%"   ],
+        [ sprintf("%%%d",    1), "%1"    ],
+        [ sprintf("%d%%str", 1), "1%str" ],
+    ];
+    for (my $i = 0; $i < @$tests; ++$i) {
+      unless ($tests->[$i][0] eq $tests->[$i][1]) {
+        warn("got: '" . $tests->[$i][0] . "', expected: '" . $tests->[$i][1] . "'");
+        return 0;
+      }
+    }
+    return 1;
+  }
+
   sub test_sprintf_all : int () {
     {
       # Invalid conversion (end of string)

--- a/t/default/modules/SPVM-Util.t
+++ b/t/default/modules/SPVM-Util.t
@@ -29,6 +29,7 @@ my $start_memory_blocks_count = SPVM::memory_blocks_count();
   ok(TestCase::Lib::SPVM::Util->test_sprintf_c);
   ok(TestCase::Lib::SPVM::Util->test_sprintf_s);
   ok(TestCase::Lib::SPVM::Util->test_sprintf_U);
+  ok(TestCase::Lib::SPVM::Util->test_sprintf_percent);
   ok(TestCase::Lib::SPVM::Util->test_sprintf_all);
 }
 


### PR DESCRIPTION
See: https://github.com/yuki-kimoto/SPVM/blob/master/lib/SPVM/Util.spvm#issuecomment-548235271

- [x] プライベートなパッケージ変数
- [x] フォーマット指定子は、素直にifで
- [x] `"%.f"` を `snprintf` に投げる処理 (precision は未対応 (固定値: 4 を使用))
- [x] `%%` の場合に適切にバッファに詰めていなかったため修正
- [x] `_convert_[l]d_to_str` でネスト除去など