### PR TITLE
flag, width and length modifier の実装

### DIFF
--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -102,49 +102,55 @@ package SPVM::Util {
     return $separated_strings;
   }
 
-  # TODO: Add the 2nd argument for width.
-  precompile sub _convert_d_to_string : string ($value : int) {
-    my $value_str = "$value";
-    my $width = 1; # TODO: Move $width to the argument.
-
-    my $value_length = length $value_str;
-    unless ($value_length < $width) {
-      return $value_str;
-    }
-
-    my $buffer = SPVM::StringBuffer->new;
-    my $space_count = $width - $value_length;
-    for (my $i = 0; $i < $space_count; ++$i) {
-      $buffer->push_char(' ');
-    }
-
-    $buffer->push($value_str);
-
-    my $result = $buffer->to_string;
-
-    return $result;
+  precompile sub _convert_c_to_string : string ($value : byte, $left_justified : int, $pad_char : byte, $width : int) {
+    return _modify_specifier([$value], $left_justified, $pad_char, $width);
   }
 
-  # TODO: Add the 2nd argument for width.
-  precompile sub _convert_ld_to_string : string ($value : long) {
-    my $value_str = "$value";
-    my $width = 1; # TODO: Move $width to the argument.
+  precompile sub _convert_s_to_string : string ($value : string, $left_justified : int, $pad_char : byte, $width : int) {
+    return _modify_specifier($value, $left_justified, $pad_char, $width);
+  }
 
+  precompile sub _convert_d_to_string : string ($value : int, $left_justified : int, $pad_char : byte, $plus_sign : int, $width : int) {
+    my $s = "";
+    if ($plus_sign && $value >= 0) {
+      $s = "+$value";
+    } else {
+      $s = "$value";
+    }
+    return _modify_specifier($s, $left_justified, $pad_char, $width);
+  }
+
+  precompile sub _convert_ld_to_string : string ($value : long, $left_justified : int, $pad_char : byte, $plus_sign : int, $width : int) {
+    my $s = "";
+    if ($plus_sign && $value >= 0) {
+      $s = "+$value";
+    } else {
+      $s = "$value";
+    }
+    return _modify_specifier($s, $left_justified, $pad_char, $width);
+  }
+
+  precompile sub _modify_specifier : string ($value_str : string, $left_justified : int, $pad_char : byte, $width : int) {
     my $value_length = length $value_str;
+
     unless ($value_length < $width) {
       return $value_str;
     }
 
     my $buffer = SPVM::StringBuffer->new;
     my $space_count = $width - $value_length;
+
+    if ($left_justified) {
+      $buffer->push($value_str);
+    }
     for (my $i = 0; $i < $space_count; ++$i) {
-      $buffer->push_char(' ');
+      $buffer->push_char($pad_char);
+    }
+    unless ($left_justified) {
+      $buffer->push($value_str);
     }
 
-    $buffer->push($value_str);
-
     my $result = $buffer->to_string;
-
     return $result;
   }
 
@@ -201,44 +207,110 @@ package SPVM::Util {
       }
 
       my $specifier_length = 1; # '%'
-      my $specifier_char = $format->[$index + $specifier_length];
 
+      # %[flags][width][.precision][length]type
+      my $pad_char = ' ';
+      my $plus_sign = 0;
+      my $left_justified = 0;
+
+      my $flag = (int)($format->[$index + $specifier_length]);
+      switch ($flag) {
+        case '0': {
+          ++$specifier_length;
+          $pad_char = '0';
+          break;
+        }
+        case '+': {
+          ++$specifier_length;
+          $plus_sign = 1;
+          break;
+        }
+        case '-': {
+          ++$specifier_length;
+          $left_justified = 1;
+          break;
+        }
+        default: {
+          $flag = 0;
+        }
+      }
+
+      my $width = 0;
+      while ($index + $specifier_length < $format_length) {
+        my $c = $format->[$index + $specifier_length];
+        if ($c < '0' || '9' < $c) {
+          last;
+        }
+        $width = $width * 10 + $c - '0';
+        ++$specifier_length;
+      }
+
+      # skip precision
+      if ($index + $specifier_length < $format_length &&
+          $format->[$index + $specifier_length] == '.') {
+        ++$specifier_length;
+        while ($index + $specifier_length < $format_length) {
+          my $c = $format->[$index + $specifier_length];
+          if ($c < '0' || '9' < $c) {
+            last;
+          }
+          ++$specifier_length;
+        }
+      }
+
+      unless ($index + $specifier_length < $format_length) {
+        die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length) . "\"";
+      }
+
+      my $length_modifier = (int)($format->[$index + $specifier_length]);
+      switch ($length_modifier) {
+        case 'l': {
+          ++$specifier_length;
+          break;
+        }
+        case 'L': {
+          ++$specifier_length;
+          break;
+        }
+        default: {
+          $length_modifier = 0;
+        }
+      }
+
+      unless ($index + $specifier_length < $format_length) {
+        die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length) . "\"";
+      }
+
+      my $specifier_char = $format->[$index + $specifier_length];
       if ($specifier_char == 'c') {
         ++$specifier_length;
         my $arg = (SPVM::Byte)$args->[$specifier_count];
-        $output->push_char($arg->val);
+        my $str = _convert_c_to_string($arg->val, $left_justified, $pad_char, $width);
+        $output->push($str);
       }
       elsif ($specifier_char == 's') {
         ++$specifier_length;
         my $arg = (string)$args->[$specifier_count];
-        $output->push($arg);
+        my $str = _convert_s_to_string($arg, $left_justified, $pad_char, $width);
+        $output->push($str);
       }
       elsif ($specifier_char == 'd') {
         ++$specifier_length;
-        my $arg = (SPVM::Int)$args->[$specifier_count];
-        my $str = _convert_d_to_string($arg->val);
+        my $str = "";
+        if ($length_modifier == 'l') {
+          my $arg = (SPVM::Long)$args->[$specifier_count];
+          $str = _convert_ld_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
+        } else {
+          my $arg = (SPVM::Int)$args->[$specifier_count];
+          $str = _convert_d_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
+        }
         $output->push($str);
       }
-      elsif ($specifier_char == 'l') {
-        ++$specifier_length;
-        unless ($index + $specifier_length < $format_length) {
-          die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length) ."\"";
-        }
-        my $specifier_char_next = $format->[$index + $specifier_length];
-        if ($specifier_char_next == 'd') {
-          ++$specifier_length;
-          my $arg = (SPVM::Long)$args->[$specifier_count];
-          my $str = _convert_ld_to_string($arg->val);
-          $output->push($str);
-        }
-        else {
-          die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length) ."\"";
-        }
-      }
-      elsif ($specifier_char == 'f') {
+      elsif ($specifier_char == 'f' || $specifier_char == 'g') {
         ++$specifier_length;
         my $arg = (SPVM::Double)$args->[$specifier_count];
-        my $str = _convert_f_to_string("%.4f", $arg->val);
+        my $specifier_str = substr($format, $index, $specifier_length);
+        my $str = _convert_f_to_string($specifier_str, $arg->val);
         $output->push($str);
       }
       elsif ($specifier_char == 'U') {

--- a/t/default/lib/TestCase/Lib/SPVM/Util.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Util.spvm
@@ -201,10 +201,14 @@ package TestCase::Lib::SPVM::Util {
 
   sub test_sprintf_d : int () {
     my $tests = [
-        [ sprintf("abc%d", 123),          "abc123"  ],
-        [ sprintf("%dabc", 123),          "123abc"  ],
-        [ sprintf("%dabc%d", 1, 10),      "1abc10"  ],
-        [ sprintf("%d%d%d", 1, 10, 100),  "110100"  ],
+        [ sprintf("abc%d", 123),          "abc123" ],
+        [ sprintf("%dabc", 123),          "123abc" ],
+        [ sprintf("%dabc%d", 1, 10),      "1abc10" ],
+        [ sprintf("%d%d%d", 1, 10, 100),  "110100" ],
+        [ sprintf("%d%d%d", 1, 10, 100),  "110100" ],
+        [ sprintf("%05d", 123),           "00123"  ],
+        [ sprintf("%+5d", 123),           " +123"  ],
+        [ sprintf("%-5d", 123),           "123  "  ],
     ];
     for (my $i = 0; $i < @$tests; ++$i) {
       unless ($tests->[$i][0] eq $tests->[$i][1]) {
@@ -231,6 +235,9 @@ package TestCase::Lib::SPVM::Util {
         [ sprintf("%ldabc", 10000000000L),                                "10000000000abc"                    ],
         [ sprintf("%ldabc%ld", 10000000000L, 20000000000L),               "10000000000abc20000000000"         ],
         [ sprintf("%ld%ld%ld", 10000000000L, 20000000000L, 30000000000L), "100000000002000000000030000000000" ],
+        [ sprintf("%013ld", 12345678901L),                                "0012345678901"                     ],
+        [ sprintf("%+13ld", 12345678901L),                                " +12345678901"                     ],
+        [ sprintf("%-13ld", 12345678901L),                                "12345678901  "                     ],
     ];
     for (my $i = 0; $i < @$tests; ++$i) {
       unless ($tests->[$i][0] eq $tests->[$i][1]) {
@@ -263,10 +270,15 @@ package TestCase::Lib::SPVM::Util {
 
   sub test_sprintf_f : int () {
     my $tests = [
-        [ sprintf("abc%f", 3.14),               "abc3.1400"           ],
-        [ sprintf("%fabc", 3.14),               "3.1400abc"           ],
-        [ sprintf("%fabc%f", 3.14, 2.71),       "3.1400abc2.7100"     ],
-        [ sprintf("%f%f%f", 3.14, 2.71, 2.67),  "3.14002.71002.6700"  ],
+        [ sprintf("abc%.2f", 3.14),                  "abc3.14"      ],
+        [ sprintf("%.2fabc", 3.14),                  "3.14abc"      ],
+        [ sprintf("%.2fabc%.2f", 3.14, 2.71),        "3.14abc2.71"  ],
+        [ sprintf("%.2f%.2f%.2f", 3.14, 2.71, 2.67), "3.142.712.67" ],
+        [ sprintf("%.10f", 3.14),                    "3.1400000000" ],
+        [ sprintf("%012.6f", 3.14),                  "00003.140000" ],
+        [ sprintf("%+12.6f", 3.14),                  "   +3.140000" ],
+        [ sprintf("%-12.6f", 3.14),                  "3.140000    " ],
+        [ sprintf("%g", 3.14),                       "3.14"         ],
     ];
     for (my $i = 0; $i < @$tests; ++$i) {
       unless ($tests->[$i][0] eq $tests->[$i][1]) {
@@ -293,6 +305,8 @@ package TestCase::Lib::SPVM::Util {
         [ sprintf("%cabc", 'x'),            "xabc"  ],
         [ sprintf("%cabc%c", 'x', 'y'),     "xabcy" ],
         [ sprintf("%c%c%c", 'x', 'y', 'z'), "xyz"   ],
+        [ sprintf("%05c", 'x'),             "0000x" ],
+        [ sprintf("%-5c", 'x'),             "x    " ],
     ];
     for (my $i = 0; $i < @$tests; ++$i) {
       unless ($tests->[$i][0] eq $tests->[$i][1]) {
@@ -319,6 +333,8 @@ package TestCase::Lib::SPVM::Util {
         [ sprintf("%sabc", "ABC"),                "ABCabc"    ],
         [ sprintf("%sabc%s", "ABC", "XYZ"),       "ABCabcXYZ" ],
         [ sprintf("%s%s%s", "ABC", "XYZ", "123"), "ABCXYZ123" ],
+        [ sprintf("%05s", "str"),                 "00str"     ],
+        [ sprintf("%-5s", "str"),                 "str  "     ],
     ];
     for (my $i = 0; $i < @$tests; ++$i) {
       unless ($tests->[$i][0] eq $tests->[$i][1]) {


### PR DESCRIPTION
See: #72

`sprintf` で以下の追加実装をしました。
- `# TODO: %[flags][width][.precision][length]type`
- `%g`