### PR TITLE
sprintf レビュー対応

### DIFF
--- a/lib/SPVM/Util.c
+++ b/lib/SPVM/Util.c
@@ -4,7 +4,7 @@ static const char* MFILE = "SPVM/Util.c";
 
 #define SPRINTF_MAX_RESULT_LEN 256
 
-int32_t SPNATIVE__SPVM__Util___convert_f_to_string(SPVM_ENV* env, SPVM_VALUE* stack) {
+int32_t SPNATIVE__SPVM__Util___snsprintf_double(SPVM_ENV* env, SPVM_VALUE* stack) {
   (void)env;
 
   void* obj_format = stack[0].oval;

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -269,22 +269,6 @@ package SPVM::Util {
             . substr($format, $specifier_base_index, $index - $specifier_base_index) . "\"";
       }
 
-      my $length_modifier = (int)($format->[$index]);
-      switch ($length_modifier) {
-        case 'l': {
-          ++$index;
-          break;
-        }
-        default: {
-          $length_modifier = 0;
-        }
-      }
-
-      unless ($index < $format_length) {
-        die "Invalid conversion in sprintf: \""
-            . substr($format, $specifier_base_index, $index - $specifier_base_index) . "\"";
-      }
-
       my $specifier_char = $format->[$index];
       if ($specifier_char == 'c') {
         ++$index;
@@ -300,14 +284,18 @@ package SPVM::Util {
       }
       elsif ($specifier_char == 'd') {
         ++$index;
-        my $str = "";
-        if ($length_modifier == 'l') {
-          my $arg = (SPVM::Long)$args->[$arg_count];
-          $str = _convert_ld_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
-        } else {
-          my $arg = (SPVM::Int)$args->[$arg_count];
-          $str = _convert_d_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
+        my $arg = (SPVM::Int)$args->[$arg_count];
+        my $str = _convert_d_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
+        $output->push($str);
+      }
+      elsif ($specifier_char == 'l') {
+        unless ($index + 1 < $format_length && $format->[$index + 1] == 'd') {
+          die "Invalid conversion in sprintf: \""
+              . substr($format, $specifier_base_index, $index - $specifier_base_index + 1) . "\"";
         }
+        $index += 2;
+        my $arg = (SPVM::Long)$args->[$arg_count];
+        my $str = _convert_ld_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
         $output->push($str);
       }
       elsif ($specifier_char == 'f' || $specifier_char == 'g') {

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -206,28 +206,29 @@ package SPVM::Util {
         die "Missing argument in sprintf";
       }
 
-      my $specifier_length = 1; # '%'
+      my $specifier_base_index = $index;
+      ++$index; # '%'
 
       # %[flags][width][.precision][length]type
       my $pad_char = ' ';
       my $plus_sign = 0;
       my $left_justified = 0;
 
-      while ($index + $specifier_length < $format_length) {
-        my $flag = (int)($format->[$index + $specifier_length]);
+      while ($index < $format_length) {
+        my $flag = (int)($format->[$index]);
         switch($flag) {
           case '0': {
-            ++$specifier_length;
+            ++$index;
             $pad_char = '0';
             break;
           }
           case '+': {
-            ++$specifier_length;
+            ++$index;
             $plus_sign = 1;
             break;
           }
           case '-': {
-            ++$specifier_length;
+            ++$index;
             $left_justified = 1;
             break;
           }
@@ -239,40 +240,40 @@ package SPVM::Util {
       }
 
       my $width = 0;
-      while ($index + $specifier_length < $format_length) {
-        my $c = $format->[$index + $specifier_length];
+      while ($index < $format_length) {
+        my $c = $format->[$index];
         if ($c < '0' || '9' < $c) {
           last;
         }
         $width = $width * 10 + $c - '0';
-        ++$specifier_length;
+        ++$index;
       }
 
       # skip precision
-      if ($index + $specifier_length < $format_length &&
-          $format->[$index + $specifier_length] == '.') {
-        ++$specifier_length;
-        while ($index + $specifier_length < $format_length) {
-          my $c = $format->[$index + $specifier_length];
+      if ($index < $format_length && $format->[$index] == '.') {
+        ++$index;
+        while ($index < $format_length) {
+          my $c = $format->[$index];
           if ($c < '0' || '9' < $c) {
             last;
           }
-          ++$specifier_length;
+          ++$index;
         }
       }
 
-      unless ($index + $specifier_length < $format_length) {
-        die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length) . "\"";
+      unless ($index < $format_length) {
+        die "Invalid conversion in sprintf: \""
+            . substr($format, $specifier_base_index, $index - $specifier_base_index) . "\"";
       }
 
-      my $length_modifier = (int)($format->[$index + $specifier_length]);
+      my $length_modifier = (int)($format->[$index]);
       switch ($length_modifier) {
         case 'l': {
-          ++$specifier_length;
+          ++$index;
           break;
         }
         case 'L': {
-          ++$specifier_length;
+          ++$index;
           break;
         }
         default: {
@@ -280,25 +281,26 @@ package SPVM::Util {
         }
       }
 
-      unless ($index + $specifier_length < $format_length) {
-        die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length) . "\"";
+      unless ($index < $format_length) {
+        die "Invalid conversion in sprintf: \""
+            . substr($format, $specifier_base_index, $index - $specifier_base_index) . "\"";
       }
 
-      my $specifier_char = $format->[$index + $specifier_length];
+      my $specifier_char = $format->[$index];
       if ($specifier_char == 'c') {
-        ++$specifier_length;
+        ++$index;
         my $arg = (SPVM::Byte)$args->[$arg_count];
         my $str = _convert_c_to_string($arg->val, $left_justified, $pad_char, $width);
         $output->push($str);
       }
       elsif ($specifier_char == 's') {
-        ++$specifier_length;
+        ++$index;
         my $arg = (string)$args->[$arg_count];
         my $str = _convert_s_to_string($arg, $left_justified, $pad_char, $width);
         $output->push($str);
       }
       elsif ($specifier_char == 'd') {
-        ++$specifier_length;
+        ++$index;
         my $str = "";
         if ($length_modifier == 'l') {
           my $arg = (SPVM::Long)$args->[$arg_count];
@@ -310,23 +312,23 @@ package SPVM::Util {
         $output->push($str);
       }
       elsif ($specifier_char == 'f' || $specifier_char == 'g') {
-        ++$specifier_length;
+        ++$index;
         my $arg = (SPVM::Double)$args->[$arg_count];
-        my $specifier_str = substr($format, $index, $specifier_length);
+        my $specifier_str = substr($format, $specifier_base_index, $index - $specifier_base_index);
         my $str = _convert_f_to_string($specifier_str, $arg->val);
         $output->push($str);
       }
       elsif ($specifier_char == 'U') {
-        ++$specifier_length;
+        ++$index;
         my $arg = (SPVM::Int)$args->[$arg_count];
         my $utf8 = uchar_to_utf8($arg->val);
         $output->push($utf8);
       }
       else {
-        die "Invalid conversion in sprintf: \"" . substr($format, $index, $specifier_length + 1) . "\"";
+        die "Invalid conversion in sprintf: \""
+            . substr($format, $specifier_base_index, $index - $specifier_base_index + 1) . "\"";
       }
 
-      $index += $specifier_length;
       ++$arg_count;
     }
 

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -161,7 +161,7 @@ package SPVM::Util {
     my $index = 0;
 
     my $output = SPVM::StringBuffer->new;
-    my $specifier_count = 0;
+    my $arg_count = 0;
 
     while ($index < $format_length) {
 
@@ -202,7 +202,7 @@ package SPVM::Util {
       }
 
       # Output the next element of $args corresponding to the specifier.
-      unless ($specifier_count < @$args) {
+      unless ($arg_count < @$args) {
         die "Missing argument in sprintf";
       }
 
@@ -284,13 +284,13 @@ package SPVM::Util {
       my $specifier_char = $format->[$index + $specifier_length];
       if ($specifier_char == 'c') {
         ++$specifier_length;
-        my $arg = (SPVM::Byte)$args->[$specifier_count];
+        my $arg = (SPVM::Byte)$args->[$arg_count];
         my $str = _convert_c_to_string($arg->val, $left_justified, $pad_char, $width);
         $output->push($str);
       }
       elsif ($specifier_char == 's') {
         ++$specifier_length;
-        my $arg = (string)$args->[$specifier_count];
+        my $arg = (string)$args->[$arg_count];
         my $str = _convert_s_to_string($arg, $left_justified, $pad_char, $width);
         $output->push($str);
       }
@@ -298,24 +298,24 @@ package SPVM::Util {
         ++$specifier_length;
         my $str = "";
         if ($length_modifier == 'l') {
-          my $arg = (SPVM::Long)$args->[$specifier_count];
+          my $arg = (SPVM::Long)$args->[$arg_count];
           $str = _convert_ld_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
         } else {
-          my $arg = (SPVM::Int)$args->[$specifier_count];
+          my $arg = (SPVM::Int)$args->[$arg_count];
           $str = _convert_d_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
         }
         $output->push($str);
       }
       elsif ($specifier_char == 'f' || $specifier_char == 'g') {
         ++$specifier_length;
-        my $arg = (SPVM::Double)$args->[$specifier_count];
+        my $arg = (SPVM::Double)$args->[$arg_count];
         my $specifier_str = substr($format, $index, $specifier_length);
         my $str = _convert_f_to_string($specifier_str, $arg->val);
         $output->push($str);
       }
       elsif ($specifier_char == 'U') {
         ++$specifier_length;
-        my $arg = (SPVM::Int)$args->[$specifier_count];
+        my $arg = (SPVM::Int)$args->[$arg_count];
         my $utf8 = uchar_to_utf8($arg->val);
         $output->push($utf8);
       }
@@ -324,10 +324,10 @@ package SPVM::Util {
       }
 
       $index += $specifier_length;
-      ++$specifier_count;
+      ++$arg_count;
     }
 
-    if ($specifier_count < @$args) {
+    if ($arg_count < @$args) {
       die "Redundant argument in sprintf";
     }
 

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -307,6 +307,7 @@ package SPVM::Util {
       die "Redundant argument in sprintf";
     }
 
-    return $buffer->to_string;
+    my $result = $buffer->to_string;
+    return $result;
   }
 }

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -275,10 +275,6 @@ package SPVM::Util {
           ++$index;
           break;
         }
-        case 'L': {
-          ++$index;
-          break;
-        }
         default: {
           $length_modifier = 0;
         }

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -132,7 +132,7 @@ package SPVM::Util {
     my $format_length = length $format;
     my $index = 0;
 
-    my $output = SPVM::StringBuffer->new;
+    my $buffer = SPVM::StringBuffer->new;
     my $arg_count = 0;
 
     while ($index < $format_length) {
@@ -158,14 +158,14 @@ package SPVM::Util {
       if ($normal_str_end + 1 < $format_length &&
           $format->[$normal_str_end + 1] == '%') {
         my $normal_str_length = $normal_str_end + 1 - $index;
-        $output->push_range($format, $index, $normal_str_length);
+        $buffer->push_range($format, $index, $normal_str_length);
         $index = $normal_str_end + 2;
         next;
       }
 
       # Output the normal sub-string of $format.
       if (my $normal_str_length = $normal_str_end - $index) {
-        $output->push_range($format, $index, $normal_str_length);
+        $buffer->push_range($format, $index, $normal_str_length);
         $index = $normal_str_end;
       }
 
@@ -246,13 +246,13 @@ package SPVM::Util {
         ++$index;
         my $arg = ((SPVM::Byte)$args->[$arg_count])->val;
         my $str = _modify_specifier([$arg], $left_justified, $pad_char, $width);
-        $output->push($str);
+        $buffer->push($str);
       }
       elsif ($specifier_char == 's') {
         ++$index;
         my $arg = (string)$args->[$arg_count];
         my $str = _modify_specifier($arg, $left_justified, $pad_char, $width);
-        $output->push($str);
+        $buffer->push($str);
       }
       elsif ($specifier_char == 'd') {
         ++$index;
@@ -264,7 +264,7 @@ package SPVM::Util {
           $s = "$arg";
         }
         my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
-        $output->push($str);
+        $buffer->push($str);
       }
       elsif ($specifier_char == 'l') {
         unless ($index + 1 < $format_length && $format->[$index + 1] == 'd') {
@@ -280,20 +280,20 @@ package SPVM::Util {
           $s = "$arg";
         }
         my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
-        $output->push($str);
+        $buffer->push($str);
       }
       elsif ($specifier_char == 'f' || $specifier_char == 'g') {
         ++$index;
         my $arg = (SPVM::Double)$args->[$arg_count];
         my $specifier_str = substr($format, $specifier_base_index, $index - $specifier_base_index);
         my $str = _snsprintf_double($specifier_str, $arg->val);
-        $output->push($str);
+        $buffer->push($str);
       }
       elsif ($specifier_char == 'U') {
         ++$index;
         my $arg = (SPVM::Int)$args->[$arg_count];
         my $utf8 = uchar_to_utf8($arg->val);
-        $output->push($utf8);
+        $buffer->push($utf8);
       }
       else {
         die "Invalid conversion in sprintf: \""
@@ -307,6 +307,6 @@ package SPVM::Util {
       die "Redundant argument in sprintf";
     }
 
-    return $output->to_string;
+    return $buffer->to_string;
   }
 }

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -213,25 +213,28 @@ package SPVM::Util {
       my $plus_sign = 0;
       my $left_justified = 0;
 
-      my $flag = (int)($format->[$index + $specifier_length]);
-      switch ($flag) {
-        case '0': {
-          ++$specifier_length;
-          $pad_char = '0';
-          break;
-        }
-        case '+': {
-          ++$specifier_length;
-          $plus_sign = 1;
-          break;
-        }
-        case '-': {
-          ++$specifier_length;
-          $left_justified = 1;
-          break;
-        }
-        default: {
-          $flag = 0;
+      while ($index + $specifier_length < $format_length) {
+        my $flag = (int)($format->[$index + $specifier_length]);
+        switch($flag) {
+          case '0': {
+            ++$specifier_length;
+            $pad_char = '0';
+            break;
+          }
+          case '+': {
+            ++$specifier_length;
+            $plus_sign = 1;
+            break;
+          }
+          case '-': {
+            ++$specifier_length;
+            $left_justified = 1;
+            break;
+          }
+          default: {
+            last;
+            break;
+          }
         }
       }
 

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -102,34 +102,6 @@ package SPVM::Util {
     return $separated_strings;
   }
 
-  precompile sub _convert_c_to_string : string ($value : byte, $left_justified : int, $pad_char : byte, $width : int) {
-    return _modify_specifier([$value], $left_justified, $pad_char, $width);
-  }
-
-  precompile sub _convert_s_to_string : string ($value : string, $left_justified : int, $pad_char : byte, $width : int) {
-    return _modify_specifier($value, $left_justified, $pad_char, $width);
-  }
-
-  precompile sub _convert_d_to_string : string ($value : int, $left_justified : int, $pad_char : byte, $plus_sign : int, $width : int) {
-    my $s = "";
-    if ($plus_sign && $value >= 0) {
-      $s = "+$value";
-    } else {
-      $s = "$value";
-    }
-    return _modify_specifier($s, $left_justified, $pad_char, $width);
-  }
-
-  precompile sub _convert_ld_to_string : string ($value : long, $left_justified : int, $pad_char : byte, $plus_sign : int, $width : int) {
-    my $s = "";
-    if ($plus_sign && $value >= 0) {
-      $s = "+$value";
-    } else {
-      $s = "$value";
-    }
-    return _modify_specifier($s, $left_justified, $pad_char, $width);
-  }
-
   precompile sub _modify_specifier : string ($value_str : string, $left_justified : int, $pad_char : byte, $width : int) {
     my $value_length = length $value_str;
 
@@ -154,7 +126,7 @@ package SPVM::Util {
     return $result;
   }
 
-  native sub _convert_f_to_string : string ($format : string, $value : double);
+  native sub _snsprintf_double : string ($format : string, $value : double);
 
   precompile sub sprintf : string ($format : string, $args : object[]...) {
     my $format_length = length $format;
@@ -272,20 +244,26 @@ package SPVM::Util {
       my $specifier_char = $format->[$index];
       if ($specifier_char == 'c') {
         ++$index;
-        my $arg = (SPVM::Byte)$args->[$arg_count];
-        my $str = _convert_c_to_string($arg->val, $left_justified, $pad_char, $width);
+        my $arg = ((SPVM::Byte)$args->[$arg_count])->val;
+        my $str = _modify_specifier([$arg], $left_justified, $pad_char, $width);
         $output->push($str);
       }
       elsif ($specifier_char == 's') {
         ++$index;
         my $arg = (string)$args->[$arg_count];
-        my $str = _convert_s_to_string($arg, $left_justified, $pad_char, $width);
+        my $str = _modify_specifier($arg, $left_justified, $pad_char, $width);
         $output->push($str);
       }
       elsif ($specifier_char == 'd') {
         ++$index;
-        my $arg = (SPVM::Int)$args->[$arg_count];
-        my $str = _convert_d_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
+        my $arg = ((SPVM::Int)$args->[$arg_count])->val;
+        my $s = "";
+        if ($plus_sign && $arg >= 0) {
+          $s = "+$arg";
+        } else {
+          $s = "$arg";
+        }
+        my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
         $output->push($str);
       }
       elsif ($specifier_char == 'l') {
@@ -294,15 +272,21 @@ package SPVM::Util {
               . substr($format, $specifier_base_index, $index - $specifier_base_index + 1) . "\"";
         }
         $index += 2;
-        my $arg = (SPVM::Long)$args->[$arg_count];
-        my $str = _convert_ld_to_string($arg->val, $left_justified, $pad_char, $plus_sign, $width);
+        my $arg = ((SPVM::Long)$args->[$arg_count])->val;
+        my $s = "";
+        if ($plus_sign && $arg >= 0) {
+          $s = "+$arg";
+        } else {
+          $s = "$arg";
+        }
+        my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
         $output->push($str);
       }
       elsif ($specifier_char == 'f' || $specifier_char == 'g') {
         ++$index;
         my $arg = (SPVM::Double)$args->[$arg_count];
         my $specifier_str = substr($format, $specifier_base_index, $index - $specifier_base_index);
-        my $str = _convert_f_to_string($specifier_str, $arg->val);
+        my $str = _snsprintf_double($specifier_str, $arg->val);
         $output->push($str);
       }
       elsif ($specifier_char == 'U') {

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -206,10 +206,12 @@ package SPVM::Util {
         die "Missing argument in sprintf";
       }
 
+      # Read specifier %[flags][width][.precision][length]type
+
       my $specifier_base_index = $index;
       ++$index; # '%'
 
-      # %[flags][width][.precision][length]type
+      # Read `flags`
       my $pad_char = ' ';
       my $plus_sign = 0;
       my $left_justified = 0;
@@ -239,6 +241,7 @@ package SPVM::Util {
         }
       }
 
+      # Read `width`
       my $width = 0;
       while ($index < $format_length) {
         my $c = $format->[$index];
@@ -249,7 +252,7 @@ package SPVM::Util {
         ++$index;
       }
 
-      # skip precision
+      # Read `precision` (just skip because type 'f' is printed by native sprintf)
       if ($index < $format_length && $format->[$index] == '.') {
         ++$index;
         while ($index < $format_length) {

--- a/t/default/lib/TestCase/Lib/SPVM/Util.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Util.spvm
@@ -278,6 +278,7 @@ package TestCase::Lib::SPVM::Util {
         [ sprintf("%012.6f", 3.14),                  "00003.140000" ],
         [ sprintf("%+12.6f", 3.14),                  "   +3.140000" ],
         [ sprintf("%-12.6f", 3.14),                  "3.140000    " ],
+        [ sprintf("%+-12.6f", 3.14),                 "+3.140000   " ],
         [ sprintf("%g", 3.14),                       "3.14"         ],
     ];
     for (my $i = 0; $i < @$tests; ++$i) {
@@ -419,6 +420,17 @@ package TestCase::Lib::SPVM::Util {
         sprintf("%d%k", 1, 2);
       };
       unless ($@ && contains($@, "Invalid conversion in sprintf: \"%k\"")) {
+        warn("got error: $@");
+        return 0;
+      }
+      $@ = undef;
+    }
+    {
+      # Invalid conversion (no type)
+      eval {
+        sprintf("%012.3", 3.14);
+      };
+      unless ($@ && contains($@, "Invalid conversion in sprintf: \"%012.3\"")) {
         warn("got error: $@");
         return 0;
       }


### PR DESCRIPTION
https://github.com/yuki-kimoto/SPVM/issues/72#issuecomment-552257978

- [x] 複数の符号対応
- [x] 指定子の長さの管理から指定子のベース位置の管理へ
- [x] 処理のまとまりが開始する位置で簡単なコメント
- [x] 大文字のLの削除
- [x] `$length_modifier` 削除関連処理
  - [x] ldの条件分岐
  - [x] 余分な例外処理
- [x] _convert_x_to_stringの非関数化
- [x] 最終出力の確認
- [x] 引数の変数名
