### PR TITLE
Sprintf review

### DIFF
--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -102,30 +102,6 @@ package SPVM::Util {
     return $separated_strings;
   }
 
-  precompile sub _modify_specifier : string ($value_str : string, $left_justified : int, $pad_char : byte, $width : int) {
-    my $value_length = length $value_str;
-
-    unless ($value_length < $width) {
-      return $value_str;
-    }
-
-    my $buffer = SPVM::StringBuffer->new;
-    my $space_count = $width - $value_length;
-
-    if ($left_justified) {
-      $buffer->push($value_str);
-    }
-    for (my $i = 0; $i < $space_count; ++$i) {
-      $buffer->push_char($pad_char);
-    }
-    unless ($left_justified) {
-      $buffer->push($value_str);
-    }
-
-    my $result = $buffer->to_string;
-    return $result;
-  }
-
   native sub _snsprintf_double : string ($format : string, $value : double);
 
   precompile sub sprintf : string ($format : string, $args : object[]...) {
@@ -242,26 +218,103 @@ package SPVM::Util {
         if ($specifier_char == 'c') {
           ++$index;
           my $arg = ((SPVM::Byte)$args->[$arg_count])->val;
-          my $str = _modify_specifier([$arg], $left_justified, $pad_char, $width);
-          $buffer->push($str);
+
+          if ($left_justified) {
+            $buffer->push_char($arg);
+            my $space_count = $width - 1;
+            if ($space_count > 0) {
+              for (; $space_count > 0; --$space_count) {
+                $buffer->push_char($pad_char);
+              }
+            }
+          }
+          else {
+            my $space_count = $width - 1;
+            if ($space_count > 0) {
+              for (; $space_count > 0; --$space_count) {
+                $buffer->push_char($pad_char);
+              }
+            }
+            $buffer->push_char($arg);
+          }
         }
         elsif ($specifier_char == 's') {
           ++$index;
           my $arg = (string)$args->[$arg_count];
-          my $str = _modify_specifier($arg, $left_justified, $pad_char, $width);
-          $buffer->push($str);
+
+          my $space_count = $width - length $arg;;
+          if ($left_justified) {
+            $buffer->push($arg);
+            for (my $i = 0; $i < $space_count; ++$i) {
+              $buffer->push_char($pad_char);
+            }
+          }
+          else {
+            for (my $i = 0; $i < $space_count; ++$i) {
+              $buffer->push_char($pad_char);
+            }
+            $buffer->push($arg);
+          }
         }
         elsif ($specifier_char == 'd') {
           ++$index;
           my $arg = ((SPVM::Int)$args->[$arg_count])->val;
-          my $s = "";
-          if ($plus_sign && $arg >= 0) {
-            $s = "+$arg";
-          } else {
-            $s = "$arg";
+          my $digits = new byte[11]; # -2147483648 has 11 digits
+          my $digit_count = 0;
+          while ($arg > 0) {
+            $digits->[$digit_count++] = (byte)('0' + $arg % 10);
+            $arg /= 10;
           }
-          my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
-          $buffer->push($str);
+
+          if ($left_justified) {
+            my $space_count = $width - $digit_count;
+
+            if ($arg < 0) {
+              $buffer->push_char('-');
+              --$space_count;
+            }
+            elsif ($plus_sign && $arg >= 0) {
+              $buffer->push_char('+');
+              --$space_count;
+            }
+
+            for (my $i = 0; $i < $digit_count; ++$i) {
+              $buffer->push_char($digits->[$digit_count - $i - 1]);
+            }
+
+            if ($space_count > 0) {
+              for (; $space_count > 0; --$space_count) {
+                $buffer->push_char($pad_char);
+              }
+            }
+          }
+          else {
+            my $space_count = $width - $digit_count;
+
+            if ($arg < 0) {
+              --$space_count;
+            }
+            elsif ($plus_sign && $arg >= 0) {
+              --$space_count;
+            }
+
+            if ($space_count > 0) {
+              for (; $space_count > 0; --$space_count) {
+                $buffer->push_char($pad_char);
+              }
+            }
+
+            if ($arg < 0) {
+              $buffer->push_char('-');
+            }
+            elsif ($plus_sign && $arg >= 0) {
+              $buffer->push_char('+');
+            }
+
+            for (my $i = 0; $i < $digit_count; ++$i) {
+              $buffer->push_char($digits->[$digit_count - $i - 1]);
+            }
+          }
         }
         elsif ($specifier_char == 'l') {
           unless ($index + 1 < $format_length && $format->[$index + 1] == 'd') {
@@ -270,14 +323,62 @@ package SPVM::Util {
           }
           $index += 2;
           my $arg = ((SPVM::Long)$args->[$arg_count])->val;
-          my $s = "";
-          if ($plus_sign && $arg >= 0) {
-            $s = "+$arg";
-          } else {
-            $s = "$arg";
+          my $digits = new byte[20]; # -9223372036854775808 has 20 digits
+          my $digit_count = 0;
+          while ($arg > 0) {
+            $digits->[$digit_count++] = (byte)('0' + $arg % 10);
+            $arg /= 10;
           }
-          my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
-          $buffer->push($str);
+
+          if ($left_justified) {
+            my $space_count = $width - $digit_count;
+
+            if ($arg < 0) {
+              $buffer->push_char('-');
+              --$space_count;
+            }
+            elsif ($plus_sign && $arg >= 0) {
+              $buffer->push_char('+');
+              --$space_count;
+            }
+
+            for (my $i = 0; $i < $digit_count; ++$i) {
+              $buffer->push_char($digits->[$digit_count - $i - 1]);
+            }
+
+            if ($space_count > 0) {
+              for (; $space_count > 0; --$space_count) {
+                $buffer->push_char($pad_char);
+              }
+            }
+          }
+          else {
+            my $space_count = $width - $digit_count;
+
+            if ($arg < 0) {
+              --$space_count;
+            }
+            elsif ($plus_sign && $arg >= 0) {
+              --$space_count;
+            }
+
+            if ($space_count > 0) {
+              for (; $space_count > 0; --$space_count) {
+                $buffer->push_char($pad_char);
+              }
+            }
+
+            if ($arg < 0) {
+              $buffer->push_char('-');
+            }
+            elsif ($plus_sign && $arg >= 0) {
+              $buffer->push_char('+');
+            }
+
+            for (my $i = 0; $i < $digit_count; ++$i) {
+              $buffer->push_char($digits->[$digit_count - $i - 1]);
+            }
+          }
         }
         elsif ($specifier_char == 'f' || $specifier_char == 'g') {
           ++$index;

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -197,7 +197,7 @@ package SPVM::Util {
           ++$index;
         }
 
-        # Read `precision` (just skip because type 'f' is printed by native sprintf)
+        # Skip `precision` because of using native sprintf.
         if ($index < $format_length && $format->[$index] == '.') {
           ++$index;
           while ($index < $format_length) {

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -134,173 +134,178 @@ package SPVM::Util {
 
     my $buffer = SPVM::StringBuffer->new;
     my $arg_count = 0;
+    my $constant_string_length = 0;
 
-    while ($index < $format_length) {
+    while ($index + $constant_string_length < $format_length) {
 
-      my $normal_str_end = $index;
-
-      # Search the next specifier '%' until the end of $format.
-      while ($normal_str_end < $format_length) {
-        if ($format->[$normal_str_end] == '%') {
-          last;
-        }
-        else {
-          ++$normal_str_end;
-        }
+      if ($format->[$index + $constant_string_length] != '%') {
+        # Read constant string
+        ++$constant_string_length;
       }
+      elsif ($index + $constant_string_length + 1 < $format_length &&
+          $format->[$index + $constant_string_length + 1] == '%') {
+        # Read %%
+        ++$constant_string_length;
 
-      if ($normal_str_end < $format_length &&
-          $format->[$normal_str_end] == '%' &&
-          $normal_str_end + 1 == $format_length) {
+        # Add constant string
+        if ($constant_string_length > 0) {
+          $buffer->push_range($format, $index, $constant_string_length);
+          $index += $constant_string_length;
+          $constant_string_length = 0;
+        }
+
+        # Skip second %
+        ++$index;
+      }
+      elsif ($index + $constant_string_length + 1 >= $format_length) {
         die "Invalid conversion in sprintf: end of string";
       }
+      else {
+        # Add constant string
+        if ($constant_string_length > 0) {
+          $buffer->push_range($format, $index, $constant_string_length);
+          $index += $constant_string_length;
+          $constant_string_length = 0;
+        }
 
-      if ($normal_str_end + 1 < $format_length &&
-          $format->[$normal_str_end + 1] == '%') {
-        my $normal_str_length = $normal_str_end + 1 - $index;
-        $buffer->push_range($format, $index, $normal_str_length);
-        $index = $normal_str_end + 2;
-        next;
-      }
+        # Read format string
 
-      # Output the normal sub-string of $format.
-      if (my $normal_str_length = $normal_str_end - $index) {
-        $buffer->push_range($format, $index, $normal_str_length);
-        $index = $normal_str_end;
-      }
+        # Check the next element of @$args corresponding to the specifier
+        unless ($arg_count < @$args) {
+          die "Missing argument in sprintf";
+        }
 
-      unless ($index < $format_length) {
-        last;
-      }
+        # Read specifier %[flags][width][.precision][length]type
 
-      # Output the next element of $args corresponding to the specifier.
-      unless ($arg_count < @$args) {
-        die "Missing argument in sprintf";
-      }
+        my $specifier_base_index = $index;
+        ++$index; # '%'
 
-      # Read specifier %[flags][width][.precision][length]type
+        # Read `flags`
+        my $pad_char = ' ';
+        my $plus_sign = 0;
+        my $left_justified = 0;
 
-      my $specifier_base_index = $index;
-      ++$index; # '%'
-
-      # Read `flags`
-      my $pad_char = ' ';
-      my $plus_sign = 0;
-      my $left_justified = 0;
-
-      while ($index < $format_length) {
-        my $flag = (int)($format->[$index]);
-        switch($flag) {
-          case '0': {
-            ++$index;
-            $pad_char = '0';
-            break;
-          }
-          case '+': {
-            ++$index;
-            $plus_sign = 1;
-            break;
-          }
-          case '-': {
-            ++$index;
-            $left_justified = 1;
-            break;
-          }
-          default: {
-            last;
-            break;
+        while ($index < $format_length) {
+          my $flag = (int)($format->[$index]);
+          switch($flag) {
+            case '0': {
+              ++$index;
+              $pad_char = '0';
+              break;
+            }
+            case '+': {
+              ++$index;
+              $plus_sign = 1;
+              break;
+            }
+            case '-': {
+              ++$index;
+              $left_justified = 1;
+              break;
+            }
+            default: {
+              last;
+              break;
+            }
           }
         }
-      }
 
-      # Read `width`
-      my $width = 0;
-      while ($index < $format_length) {
-        my $c = $format->[$index];
-        if ($c < '0' || '9' < $c) {
-          last;
-        }
-        $width = $width * 10 + $c - '0';
-        ++$index;
-      }
-
-      # Read `precision` (just skip because type 'f' is printed by native sprintf)
-      if ($index < $format_length && $format->[$index] == '.') {
-        ++$index;
+        # Read `width`
+        my $width = 0;
         while ($index < $format_length) {
           my $c = $format->[$index];
           if ($c < '0' || '9' < $c) {
             last;
           }
+          $width = $width * 10 + $c - '0';
           ++$index;
         }
-      }
 
-      unless ($index < $format_length) {
-        die "Invalid conversion in sprintf: \""
-            . substr($format, $specifier_base_index, $index - $specifier_base_index) . "\"";
-      }
-
-      my $specifier_char = $format->[$index];
-      if ($specifier_char == 'c') {
-        ++$index;
-        my $arg = ((SPVM::Byte)$args->[$arg_count])->val;
-        my $str = _modify_specifier([$arg], $left_justified, $pad_char, $width);
-        $buffer->push($str);
-      }
-      elsif ($specifier_char == 's') {
-        ++$index;
-        my $arg = (string)$args->[$arg_count];
-        my $str = _modify_specifier($arg, $left_justified, $pad_char, $width);
-        $buffer->push($str);
-      }
-      elsif ($specifier_char == 'd') {
-        ++$index;
-        my $arg = ((SPVM::Int)$args->[$arg_count])->val;
-        my $s = "";
-        if ($plus_sign && $arg >= 0) {
-          $s = "+$arg";
-        } else {
-          $s = "$arg";
+        # Read `precision` (just skip because type 'f' is printed by native sprintf)
+        if ($index < $format_length && $format->[$index] == '.') {
+          ++$index;
+          while ($index < $format_length) {
+            my $c = $format->[$index];
+            if ($c < '0' || '9' < $c) {
+              last;
+            }
+            ++$index;
+          }
         }
-        my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
-        $buffer->push($str);
-      }
-      elsif ($specifier_char == 'l') {
-        unless ($index + 1 < $format_length && $format->[$index + 1] == 'd') {
+
+        unless ($index < $format_length) {
+          die "Invalid conversion in sprintf: \""
+              . substr($format, $specifier_base_index, $index - $specifier_base_index) . "\"";
+        }
+
+        my $specifier_char = $format->[$index];
+        if ($specifier_char == 'c') {
+          ++$index;
+          my $arg = ((SPVM::Byte)$args->[$arg_count])->val;
+          my $str = _modify_specifier([$arg], $left_justified, $pad_char, $width);
+          $buffer->push($str);
+        }
+        elsif ($specifier_char == 's') {
+          ++$index;
+          my $arg = (string)$args->[$arg_count];
+          my $str = _modify_specifier($arg, $left_justified, $pad_char, $width);
+          $buffer->push($str);
+        }
+        elsif ($specifier_char == 'd') {
+          ++$index;
+          my $arg = ((SPVM::Int)$args->[$arg_count])->val;
+          my $s = "";
+          if ($plus_sign && $arg >= 0) {
+            $s = "+$arg";
+          } else {
+            $s = "$arg";
+          }
+          my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
+          $buffer->push($str);
+        }
+        elsif ($specifier_char == 'l') {
+          unless ($index + 1 < $format_length && $format->[$index + 1] == 'd') {
+            die "Invalid conversion in sprintf: \""
+                . substr($format, $specifier_base_index, $index - $specifier_base_index + 1) . "\"";
+          }
+          $index += 2;
+          my $arg = ((SPVM::Long)$args->[$arg_count])->val;
+          my $s = "";
+          if ($plus_sign && $arg >= 0) {
+            $s = "+$arg";
+          } else {
+            $s = "$arg";
+          }
+          my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
+          $buffer->push($str);
+        }
+        elsif ($specifier_char == 'f' || $specifier_char == 'g') {
+          ++$index;
+          my $arg = (SPVM::Double)$args->[$arg_count];
+          my $specifier_str = substr($format, $specifier_base_index, $index - $specifier_base_index);
+          my $str = _snsprintf_double($specifier_str, $arg->val);
+          $buffer->push($str);
+        }
+        elsif ($specifier_char == 'U') {
+          ++$index;
+          my $arg = (SPVM::Int)$args->[$arg_count];
+          my $utf8 = uchar_to_utf8($arg->val);
+          $buffer->push($utf8);
+        }
+        else {
           die "Invalid conversion in sprintf: \""
               . substr($format, $specifier_base_index, $index - $specifier_base_index + 1) . "\"";
         }
-        $index += 2;
-        my $arg = ((SPVM::Long)$args->[$arg_count])->val;
-        my $s = "";
-        if ($plus_sign && $arg >= 0) {
-          $s = "+$arg";
-        } else {
-          $s = "$arg";
-        }
-        my $str = _modify_specifier($s, $left_justified, $pad_char, $width);
-        $buffer->push($str);
-      }
-      elsif ($specifier_char == 'f' || $specifier_char == 'g') {
-        ++$index;
-        my $arg = (SPVM::Double)$args->[$arg_count];
-        my $specifier_str = substr($format, $specifier_base_index, $index - $specifier_base_index);
-        my $str = _snsprintf_double($specifier_str, $arg->val);
-        $buffer->push($str);
-      }
-      elsif ($specifier_char == 'U') {
-        ++$index;
-        my $arg = (SPVM::Int)$args->[$arg_count];
-        my $utf8 = uchar_to_utf8($arg->val);
-        $buffer->push($utf8);
-      }
-      else {
-        die "Invalid conversion in sprintf: \""
-            . substr($format, $specifier_base_index, $index - $specifier_base_index + 1) . "\"";
-      }
 
-      ++$arg_count;
+        ++$arg_count;
+      }
+    }
+
+    # Add constant string
+    if ($constant_string_length > 0) {
+      $buffer->push_range($format, $index, $constant_string_length);
+      $index += $constant_string_length;
+      $constant_string_length = 0;
     }
 
     my $result = $buffer->to_string;

--- a/lib/SPVM/Util.spvm
+++ b/lib/SPVM/Util.spvm
@@ -303,10 +303,6 @@ package SPVM::Util {
       ++$arg_count;
     }
 
-    if ($arg_count < @$args) {
-      die "Redundant argument in sprintf";
-    }
-
     my $result = $buffer->to_string;
     return $result;
   }

--- a/t/default/lib/TestCase/Lib/SPVM/Util.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Util.spvm
@@ -536,17 +536,6 @@ package TestCase::Lib::SPVM::Util {
       $@ = undef;
     }
     {
-      # Redundant argument
-      eval {
-        sprintf("%d", 1, 2);
-      };
-      unless ($@ && contains($@, "Redundant argument in sprintf")) {
-        warn("got error: $@");
-        return 0;
-      }
-      $@ = undef;
-    }
-    {
       # Missing argument
       eval {
         sprintf("%d%d", 1);


### PR DESCRIPTION
- [x] 定数文字列であった場合と、フォーマット文字列であった場合で分岐
- [x] 定数文字列の末尾の位置を探す
- [x] 引数が多かった場合の仕様変更
- 精度の値の保存 - 精度を保存した方法で書いてみましたが _snsprintf_double に渡す際に string の object 生成は避けられなかったため、従来どおり精度を skip して、format 全体を substr して snsprintf に渡す方法にしてみました。
- [x] %c, %d, %ldの場合の文字列・オブジェクトの生成を0回に