### PR TITLE
nanの引数を使うようにする & 引数が undef の場合を弾く

### DIFF
--- a/lib/SPVM/Math.c
+++ b/lib/SPVM/Math.c
@@ -3,6 +3,8 @@
 #include <math.h>
 #include <fenv.h>
 
+static const char* MFILE = "SPVM/Math.c";
+
 int32_t SPNATIVE__SPVM__Math__pi(SPVM_ENV* env, SPVM_VALUE* stack) {
   (void)env;
   (void)stack;
@@ -1224,7 +1226,11 @@ int32_t SPNATIVE__SPVM__Math__nan(SPVM_ENV* env, SPVM_VALUE* stack) {
   (void)env;
 
   void* string = stack[0].oval;
-  const char* tagp = string ? (const char*)env->get_elems_byte(env, string) : NULL;
+  if (string == NULL) {
+    SPVM_DIE("String must be defined", MFILE, __LINE__);
+  }
+
+  const char* tagp = (const char*)env->get_elems_byte(env, string);
   double value = nan(tagp);
 
   stack[0].dval = value;
@@ -1236,7 +1242,11 @@ int32_t SPNATIVE__SPVM__Math__nanf(SPVM_ENV* env, SPVM_VALUE* stack) {
   (void)env;
 
   void* string = stack[0].oval;
-  const char* tagp = string ? (const char*)env->get_elems_byte(env, string) : NULL;
+  if (string == NULL) {
+    SPVM_DIE("String must be defined", MFILE, __LINE__);
+  }
+
+  const char* tagp = (const char*)env->get_elems_byte(env, string);
   float value = nanf(tagp);
 
   stack[0].fval = value;

--- a/lib/SPVM/Math.c
+++ b/lib/SPVM/Math.c
@@ -1223,7 +1223,9 @@ int32_t SPNATIVE__SPVM__Math__copysignf(SPVM_ENV* env, SPVM_VALUE* stack) {
 int32_t SPNATIVE__SPVM__Math__nan(SPVM_ENV* env, SPVM_VALUE* stack) {
   (void)env;
 
-  double value = nan(NULL);
+  void* string = stack[0].oval;
+  const char* tagp = string ? (const char*)env->get_elems_byte(env, string) : NULL;
+  double value = nan(tagp);
 
   stack[0].dval = value;
 
@@ -1233,7 +1235,9 @@ int32_t SPNATIVE__SPVM__Math__nan(SPVM_ENV* env, SPVM_VALUE* stack) {
 int32_t SPNATIVE__SPVM__Math__nanf(SPVM_ENV* env, SPVM_VALUE* stack) {
   (void)env;
 
-  float value = nanf(NULL);
+  void* string = stack[0].oval;
+  const char* tagp = string ? (const char*)env->get_elems_byte(env, string) : NULL;
+  float value = nanf(tagp);
 
   stack[0].fval = value;
 

--- a/t/default/SPVM-Math.t
+++ b/t/default/SPVM-Math.t
@@ -189,6 +189,10 @@ ok(TestCase::Lib::SPVM::Math->test_islessgreaterf);
 ok(TestCase::Lib::SPVM::Math->test_isunordered);
 ok(TestCase::Lib::SPVM::Math->test_isunorderedf);
 
+# All object is freed
+my $end_memory_blocks_count = SPVM::get_memory_blocks_count();
+is($end_memory_blocks_count, $start_memory_blocks_count);
+
 __END__
 
 # Call subroutine

--- a/t/default/lib/TestCase/Lib/SPVM/Math.spvm
+++ b/t/default/lib/TestCase/Lib/SPVM/Math.spvm
@@ -1,6 +1,6 @@
 package TestCase::Lib::SPVM::Math {
   use SPVM::Math;
-  use SPVM::Util(PI, INT8_MIN, INT8_MAX, INT16_MIN, INT16_MAX, INT32_MIN, INT32_MAX, INT64_MIN, INT64_MAX, FLT_MIN, FLT_MAX, DBL_MIN, DBL_MAX);
+  use SPVM::Util(contains, PI, INT8_MIN, INT8_MAX, INT16_MIN, INT16_MAX, INT32_MIN, INT32_MAX, INT64_MIN, INT64_MAX, FLT_MIN, FLT_MAX, DBL_MIN, DBL_MAX);
 
   sub test_pi : int () {
     my $pi = PI();
@@ -2019,22 +2019,30 @@ package TestCase::Lib::SPVM::Math {
   }
 
   sub test_nan : int () {
-    unless (SPVM::Math->isnan(SPVM::Math->nan(undef))) {
-      return 0;
-    }
     unless (SPVM::Math->isnan(SPVM::Math->nan("test"))) {
       return 0;
     }
+    eval {
+      SPVM::Math->nan(undef);
+    };
+    unless ($@ && contains($@, "String must be defined")) {
+      return 0;
+    }
+    $@ = undef;
     return 1;
   }
 
   sub test_nanf : int () {
-    unless (SPVM::Math->isnan(SPVM::Math->nanf(undef))) {
-      return 0;
-    }
     unless (SPVM::Math->isnan(SPVM::Math->nanf("test"))) {
       return 0;
     }
+    eval {
+      SPVM::Math->nanf(undef);
+    };
+    unless ($@ && contains($@, "String must be defined")) {
+      return 0;
+    }
+    $@ = undef;
     return 1;
   }
   sub test_nextafter : int () {


### PR DESCRIPTION
nanの引数を使うようにします。`nan(const char* tagp)` の tagp が NaN の表現に影響する場合があるとのことでした。
https://linuxjm.osdn.jp/html/LDP_man-pages/man3/nan.3.html
引数が `undef` のときは例外を送出します。

また、テストで memory leak をチェックする文が書けていたので追加しました。