### PR TITLE
Add github Issues as the bug tracker

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -136,6 +136,9 @@ WriteMakefile(
                 url  => 'https://github.com/yuki-kimoto/SPVM.git',
                 web  => 'https://github.com/yuki-kimoto/SPVM',
             },
+            bugtracker => {
+                web => "https://github.com/yuki-kimoto/SPVM/issues",
+            },            
         },
     },
     EXE_FILES => ['script/spvmcc', 'script/spvmdist'],


### PR DESCRIPTION
I am a participant of Mr Szabo's Perl open source development course. I found SPVM a very interesting project and hope to be able to take part in it. I am studying the code base.

Add the github Issues as the issue tracker is an assignment of Mr Szabo's course. I saw that you are already using github Issues. I hope this pull request is useful.

Thanks.