### PR TITLE
get_class_var_byteの試験関数であるget_class_var_byte_nativeを追加。

### DIFF
--- a/t/02_vm/06_native_api/native_api.t
+++ b/t/02_vm/06_native_api/native_api.t
@@ -84,7 +84,7 @@ my $start_memory_blocks_count = SPVM::api->get_memory_blocks_count();
 
 # get_class_var_byte
 {
-  ok(SPVM::TestCase::NativeAPI->get_class_var_byte_native);
+  ok(SPVM::TestCase::NativeAPI->get_class_var_byte);
 }
 
 # Field

--- a/t/02_vm/06_native_api/native_api.t
+++ b/t/02_vm/06_native_api/native_api.t
@@ -84,7 +84,7 @@ my $start_memory_blocks_count = SPVM::api->get_memory_blocks_count();
 
 # get_class_var_byte
 {
-  is(SPVM::TestCase::NativeAPI->get_class_var_test(0xf), 0xf);
+  ok(SPVM::TestCase::NativeAPI->get_class_var_byte_native);
 }
 
 # Field

--- a/t/02_vm/06_native_api/native_api.t
+++ b/t/02_vm/06_native_api/native_api.t
@@ -82,6 +82,11 @@ my $start_memory_blocks_count = SPVM::api->get_memory_blocks_count();
   ok(SPVM::TestCase::NativeAPI->push_mortal_multi);
 }
 
+# get_class_var_byte
+{
+  is(SPVM::TestCase::NativeAPI->get_class_var_test(0xf), 0xf);
+}
+
 # Field
 {
   ok(SPVM::TestCase::NativeAPI->get_field_byte_by_name);

--- a/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
+++ b/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
@@ -251,6 +251,31 @@ int32_t SPVM__TestCase__NativeAPI__get_class_var(SPVM_ENV* env, SPVM_VALUE* stac
   return 0;
 }
 
+int32_t SPVM__TestCase__NativeAPI__get_class_var_test(SPVM_ENV* env, SPVM_VALUE* stack) {
+  
+  int32_t error = 0;
+
+  void* class_var = env->get_class_var(env, stack, "TestCase::NativeAPI", "$INT_VALUE");
+  
+  if (!class_var) {
+    stack[0].ival = 0;
+    return 0;
+  }
+  
+   env->set_class_var_byte(env, stack, class_var, 0x0f);
+  
+  int8_t class_var_byte = env->get_class_var_byte(env, stack, class_var);
+  
+  if (!(class_var_byte == 0x0f)) {
+    stack[0].ival = 0;
+    return 0;
+  }
+ 
+  stack[0].ival = class_var_byte;
+  
+  return 0;
+}
+
 int32_t SPVM__TestCase__NativeAPI__get_class_var_byte_by_name_test(SPVM_ENV* env, SPVM_VALUE* stack) {
   
   int32_t error = 0;

--- a/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
+++ b/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
@@ -262,8 +262,12 @@ int32_t SPVM__TestCase__NativeAPI__get_class_var_byte_native(SPVM_ENV* env, SPVM
   
   int8_t value = env->get_class_var_byte(env, stack, class_var);
   
-  stack[0].ival = value;
-  
+  if (!(value == 0x0F)) {
+    stack[0].ival = 0;
+    return 0;
+  }
+
+  stack[0].ival = 1;
   return 0;
 }
 

--- a/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
+++ b/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
@@ -251,27 +251,27 @@ int32_t SPVM__TestCase__NativeAPI__get_class_var(SPVM_ENV* env, SPVM_VALUE* stac
   return 0;
 }
 
-int32_t SPVM__TestCase__NativeAPI__get_class_var_test(SPVM_ENV* env, SPVM_VALUE* stack) {
+int32_t SPVM__TestCase__NativeAPI__get_class_var_byte_native(SPVM_ENV* env, SPVM_VALUE* stack) {
   
   int32_t error = 0;
 
-  void* class_var = env->get_class_var(env, stack, "TestCase::NativeAPI", "$INT_VALUE");
+  void* class_var = env->get_class_var(env, stack, "TestCase::NativeAPI", "$BYTE_VALUE");
   
   if (!class_var) {
     stack[0].ival = 0;
     return 0;
   }
   
-   env->set_class_var_byte(env, stack, class_var, 0x0f);
+  env->set_class_var_byte(env, stack, class_var, 0xf);
   
-  int8_t class_var_byte = env->get_class_var_byte(env, stack, class_var);
+  int8_t value = env->get_class_var_byte(env, stack, class_var);
   
-  if (!(class_var_byte == 0x0f)) {
+  if (!(value == 0xf)) {
     stack[0].ival = 0;
     return 0;
   }
  
-  stack[0].ival = class_var_byte;
+  stack[0].ival = 1;
   
   return 0;
 }

--- a/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
+++ b/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
@@ -262,8 +262,6 @@ int32_t SPVM__TestCase__NativeAPI__get_class_var_byte_native(SPVM_ENV* env, SPVM
     return 0;
   }
   
-  env->set_class_var_byte(env, stack, class_var, 0xf);
-  
   int8_t value = env->get_class_var_byte(env, stack, class_var);
   
   if (!(value == 0xf)) {
@@ -271,7 +269,7 @@ int32_t SPVM__TestCase__NativeAPI__get_class_var_byte_native(SPVM_ENV* env, SPVM
     return 0;
   }
  
-  stack[0].ival = 1;
+  stack[0].ival = value;
   
   return 0;
 }

--- a/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
+++ b/t/02_vm/lib/SPVM/TestCase/NativeAPI.c
@@ -253,8 +253,6 @@ int32_t SPVM__TestCase__NativeAPI__get_class_var(SPVM_ENV* env, SPVM_VALUE* stac
 
 int32_t SPVM__TestCase__NativeAPI__get_class_var_byte_native(SPVM_ENV* env, SPVM_VALUE* stack) {
   
-  int32_t error = 0;
-
   void* class_var = env->get_class_var(env, stack, "TestCase::NativeAPI", "$BYTE_VALUE");
   
   if (!class_var) {
@@ -264,11 +262,6 @@ int32_t SPVM__TestCase__NativeAPI__get_class_var_byte_native(SPVM_ENV* env, SPVM
   
   int8_t value = env->get_class_var_byte(env, stack, class_var);
   
-  if (!(value == 0xf)) {
-    stack[0].ival = 0;
-    return 0;
-  }
- 
   stack[0].ival = value;
   
   return 0;

--- a/t/02_vm/lib/SPVM/TestCase/NativeAPI.spvm
+++ b/t/02_vm/lib/SPVM/TestCase/NativeAPI.spvm
@@ -57,8 +57,20 @@ class TestCase::NativeAPI {
   native static method check_native_api_constant_values : int ();
   
   native static method get_class_var : int ();
+
+  static method get_class_var_byte : int () {
+    $BYTE_VALUE = 0x0F;
+    
+    my $value = TestCase::NativeAPI->get_class_var_byte_native();
+    
+    unless ($value == 0x0F) {
+      return 0;
+    }
+    
+    return 1;
+  } 
   native static method get_class_var_byte_native : int ();
-  
+
   static method get_class_var_byte_by_name : int () {
     
     $BYTE_VALUE = (byte)Fn->INT8_MIN;

--- a/t/02_vm/lib/SPVM/TestCase/NativeAPI.spvm
+++ b/t/02_vm/lib/SPVM/TestCase/NativeAPI.spvm
@@ -61,9 +61,9 @@ class TestCase::NativeAPI {
   static method get_class_var_byte : int () {
     $BYTE_VALUE = 0x0F;
     
-    my $value = TestCase::NativeAPI->get_class_var_byte_native();
-    
-    unless ($value == 0x0F) {
+    my $success = TestCase::NativeAPI->get_class_var_byte_native();
+
+    unless ($success) {
       return 0;
     }
     

--- a/t/02_vm/lib/SPVM/TestCase/NativeAPI.spvm
+++ b/t/02_vm/lib/SPVM/TestCase/NativeAPI.spvm
@@ -57,6 +57,7 @@ class TestCase::NativeAPI {
   native static method check_native_api_constant_values : int ();
   
   native static method get_class_var : int ();
+  native static method get_class_var_byte_native : int ();
   
   static method get_class_var_byte_by_name : int () {
     


### PR DESCRIPTION
get_class_var_byteの試験関数であるget_class_var_byte_nativeを追加。

試験の流れ... SPVM側でbyte型のクラス変数を設定する。C言語側のget_class_var_byteで正しく値が取れる.